### PR TITLE
Respect RAILS_RELATIVE_URL_ROOT in url helpers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,14 @@ class ApplicationController < ActionController::Base
   end
 
   include BreadcrumbsHelper::ControllerMethods
+
+  protected
+
+  if Rails.application.config.action_controller.default_url_options[:script_name].present?
+    def url_options
+      super.merge(
+        script_name: Rails.application.config.action_controller.default_url_options[:script_name]
+      )
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,13 @@ module TrainersHub
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+
+    config.action_controller.default_url_options = {}
+    if ENV["RAILS_RELATIVE_URL_ROOT"]
+      config.action_controller.default_url_options.merge!(
+        script_name: ENV["RAILS_RELATIVE_URL_ROOT"]
+      )
+    end
   end
 end


### PR DESCRIPTION
We should just be able to set `RAILS_RELATIVE_URL_ROOT`, but there's a bug in rails/rails (#24393). This is a workaround for now.