### PR TITLE
Use a uuid in the lesson permalink

### DIFF
--- a/app/controllers/lesson_plans_controller.rb
+++ b/app/controllers/lesson_plans_controller.rb
@@ -1,7 +1,7 @@
 class LessonPlansController < ApplicationController
   def show
     if params[:id]
-      @lesson_plan = LessonPlan.find(params[:id])
+      @lesson_plan = LessonPlan.find_by(key: params[:id])
     else
       @lesson_plan = helpers.current_lesson_plan
     end

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -14,6 +14,6 @@ class LessonPlan < ApplicationRecord
   private
 
   def set_key
-    self.key = SecureRandom.uuid
+    self.key = SecureRandom.urlsafe_base64
   end
 end

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -3,4 +3,17 @@ class LessonPlan < ApplicationRecord
   has_many :lessons, through: :lesson_plan_lessons
 
   accepts_nested_attributes_for :lesson_plan_lessons, allow_destroy: true
+
+  validates_uniqueness_of :key
+  before_create :create_key
+
+  def to_param
+    key
+  end
+
+  private
+
+  def create_key
+    self.key = SecureRandom.uuid
+  end
 end

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -5,7 +5,7 @@ class LessonPlan < ApplicationRecord
   accepts_nested_attributes_for :lesson_plan_lessons, allow_destroy: true
 
   validates_uniqueness_of :key
-  before_create :create_key
+  before_validation :set_key, on: :create
 
   def to_param
     key
@@ -13,7 +13,7 @@ class LessonPlan < ApplicationRecord
 
   private
 
-  def create_key
+  def set_key
     self.key = SecureRandom.uuid
   end
 end

--- a/db/migrate/20171024185449_add_key_to_lesson_plans.rb
+++ b/db/migrate/20171024185449_add_key_to_lesson_plans.rb
@@ -1,0 +1,5 @@
+class AddKeyToLessonPlans < ActiveRecord::Migration[5.1]
+  def change
+    add_column :lesson_plans, :key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023201330) do
+ActiveRecord::Schema.define(version: 20171024185449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20171023201330) do
     t.integer "lessons_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "key"
   end
 
   create_table "lesson_resources", force: :cascade do |t|


### PR DESCRIPTION
This prevents users from incrementing the id in their own permalink to find other lesson plans.

I decided not to switch the whole model over to using a postgres-generated uuid as the primary database key because it requires any table referencing this one to use that column type as well, which I thought might be confusing for people working on this site in the future.