### PR TITLE
Wrap long links in lesson containers

### DIFF
--- a/app/assets/stylesheets/application/lessons.scss
+++ b/app/assets/stylesheets/application/lessons.scss
@@ -207,7 +207,11 @@
     margin: -1px 0 2rem;
     padding: 1rem 0.5rem 2rem;
     z-index: 0;
-    word-wrap: break-word;
+
+    a {
+      word-wrap: break-word;
+    }
+
     h3 {
       font-size: 1.1rem;
       line-height: 1.1rem;

--- a/app/assets/stylesheets/application/lessons.scss
+++ b/app/assets/stylesheets/application/lessons.scss
@@ -207,6 +207,7 @@
     margin: -1px 0 2rem;
     padding: 1rem 0.5rem 2rem;
     z-index: 0;
+    word-wrap: break-word;
     h3 {
       font-size: 1.1rem;
       line-height: 1.1rem;


### PR DESCRIPTION
Fixes #291. This isn't much of a problem now that we aren't showing the full URL on links on sec.eff.org, but it has an easy fix and will prevent issues in the future.