### PR TITLE
Inline pdf stylesheet

### DIFF
--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -6,7 +6,10 @@
 
   <title><%= page_title %></title>
 
-  <%= wicked_pdf_stylesheet_link_tag("pdf") %>
+  <style type="text/css">
+    <%= File.read(Rails.root.join("app/assets/stylesheets/pdf.css")).html_safe %>
+  </style>
+
 </head>
 
 <body class="section-<%= controller_name %> page-<%= action_name %>">


### PR DESCRIPTION
I can't seem to fix #358, so for now I'm just embedding the stylesheet for PDFs directly into the layout. This will get them working again while we debug the issue.