### PR TITLE
Use more page-specific og tags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  include Sharing
+
   def not_found
     raise ActionController::RoutingError.new("Not Found")
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -14,6 +14,7 @@ class ArticlesController < ApplicationController
   def show
     @article = Article.friendly.find(params[:id])
     protect_unpublished! @article
+    og_object @article
     breadcrumbs @article.name
   end
 end

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -15,6 +15,7 @@ class BlogController < ApplicationController
     @blog_post = BlogPost.friendly.find(params[:id])
     protect_unpublished! @blog_post
     breadcrumbs @blog_post.name
+    og_object @blog_post
   end
 
   private

--- a/app/controllers/concerns/sharing.rb
+++ b/app/controllers/concerns/sharing.rb
@@ -1,0 +1,10 @@
+module Sharing
+  extend ActiveSupport::Concern
+
+  protected
+
+  def og_object(object, name: nil, description: nil)
+    @og_title = name || object.name
+    @og_description = description || helpers.preview(object, allowed_tags: [])
+  end
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -8,6 +8,8 @@ class LessonsController < ApplicationController
     @lesson = @topic.lessons.with_level(params[:id]).take
     redirect_to @topic && return if @lesson.nil?
 
+    og_object @lesson, description: ""
+
     respond_to do |format|
       format.html { render "topics/show" }
       format.js

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -8,6 +8,8 @@ class MaterialsController < ApplicationController
 
   def show
     @material = Material.published.friendly.find(params[:id])
+    og_object @material
+
     @topics = Topic.joins(:lessons).
       where("lessons.suggested_materials LIKE ?",
             "%#{ material_path(@material) }%")

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -14,8 +14,10 @@ class TopicsController < ApplicationController
   def show
     @topic = Topic.friendly.find(params[:id])
     protect_unpublished! @topic
+
     @lesson = @topic.lessons.take!
     breadcrumbs @topic.name
+    og_object @lesson, description: ""
 
     respond_to do |format|
       format.html

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -6,8 +6,10 @@ module ContentHelper
   def preview(object, allowed_tags: allowed_tags_for_preview)
     if object.respond_to?(:summary?) && object.summary?
       html = object.summary
-    else
+    elsif object.respond_to?(:body)
       html = object.body
+    else
+      html = object.description
     end
 
     html = truncate(sanitize(html, tags: allowed_tags),

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -3,14 +3,14 @@ module ContentHelper
     %w(b strong i em u s strike del p)
   end
 
-  def preview(object)
+  def preview(object, allowed_tags: allowed_tags_for_preview)
     if object.respond_to?(:summary?) && object.summary?
       html = object.summary
     else
       html = object.body
     end
 
-    html = truncate(sanitize(html, tags: allowed_tags_for_preview),
+    html = truncate(sanitize(html, tags: allowed_tags),
                     length: 500, escape: false, separator: /\s/)
 
     Nokogiri::HTML.fragment(html).to_html.html_safe # rubocop:disable Rails/OutputSafety

--- a/app/helpers/social_media_helper.rb
+++ b/app/helpers/social_media_helper.rb
@@ -1,0 +1,17 @@
+module SocialMediaHelper
+  def url_for_share
+    request.original_url
+  end
+
+  def og_title
+    @og_title.presence || page_title
+  end
+
+  def og_description
+    @og_description.presence || "The Security Education Companion is a resource for people teaching digital security to their friends and neighbors."
+  end
+
+  def og_image
+    @og_image.presence || image_url("sec-og-image.png")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <%= tag :meta, property: "og:title", content: "Security Education Companion" %>
+  <%= tag :meta, property: "og:title", content: og_title.try(:strip) %>
   <%= tag :meta, property: "og:type", content: "website" %>
-  <%= tag :meta, property: "og:url", content: "https://sec.eff.org" %>
-  <%= tag :meta, property: "og:image", content: image_url("sec-og-image.png") %>
-  <%= tag :meta, property: "og:description", content: "The Security Education Companion is a resource for people teaching digital security to their friends and neighbors." %>
+  <%= tag :meta, property: "og:url", content: url_for_share %>
+  <%= tag :meta, property: "og:image", content: og_image %>
+  <%= tag :meta, property: "og:description", content: og_description.try(:strip) %>
 
   <title><%= page_title %></title>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Adds a method `#og_object` to controllers which can be used to change what title/description is used for og tags. For example `og_object(@article)` will make the page use the article's title/summary for the property values.

This could use some additional development/improvement down the line. I'm not entirely happy that you have to explicitly call `#og_object` within the controller action -- that could be more "magical" somehow. Another enhancement would be to allow og:image to be customized.

Fixes #386.