### PR TITLE
Add feedback forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "flipper", github: "jnunemaker/flipper"
 # ActiveJob backend
 gem "delayed_job_active_record"
 
+# Prevent form submissions by bots
+gem "invisible_captcha"
+
 # Content administration
 gem "active_material", github: "vigetlabs/active_material"
 gem "activeadmin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
       has_scope (~> 0.6)
       railties (>= 3.2, < 5.2.x)
       responders
+    invisible_captcha (0.10.0)
+      rails (>= 3.2.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -384,6 +386,7 @@ DEPENDENCIES
   foundation-rails (>= 6)
   friendly_id
   httparty
+  invisible_captcha
   jbuilder (~> 2.5)
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -1,0 +1,8 @@
+ActiveAdmin.register Feedback do
+  menu priority: 7
+
+  member_action :show do
+    @feedback = resource
+    render layout: "active_admin"
+  end
+end

--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register Feedback do
   menu priority: 7
 
+  actions :all, except: [:edit]
+
   member_action :show do
     @feedback = resource
     render layout: "active_admin"

--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Feedback do
-  menu priority: 7
+  menu(false)
 
   actions :all, except: [:edit]
 

--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -3,6 +3,8 @@ ActiveAdmin.register Feedback do
 
   actions :all, except: [:edit]
 
+  filter :created_at
+
   member_action :show do
     @feedback = resource
     render layout: "active_admin"

--- a/app/admin/survey_question.rb
+++ b/app/admin/survey_question.rb
@@ -1,10 +1,12 @@
 ActiveAdmin.register SurveyQuestion do
-  menu priority: 6
+  menu(false)
 
   config.sort_order = "position_desc"
 
-  permit_params :prompt, :required,
+  permit_params :prompt, :required, :survey,
                 options_attributes: [:id, :position, :value]
+
+  filter :survey
 
   index do
     id_column
@@ -27,6 +29,9 @@ ActiveAdmin.register SurveyQuestion do
 
       f.input :required
     end
+
+    survey_question.survey = "/feedback" if survey_question.new_record?
+    f.input :survey, as: :hidden
 
     f.actions
   end

--- a/app/admin/survey_question.rb
+++ b/app/admin/survey_question.rb
@@ -6,6 +6,17 @@ ActiveAdmin.register SurveyQuestion do
   permit_params :prompt, :required,
                 options_attributes: [:id, :position, :value]
 
+  index do
+    id_column
+
+    column :prompt
+    column :required
+
+    actions do |resource|
+      link_to "Show Responses", show_responses_admin_survey_question_path(resource)
+    end
+  end
+
   form do |f|
     f.inputs do
       f.input :prompt
@@ -18,5 +29,10 @@ ActiveAdmin.register SurveyQuestion do
     end
 
     f.actions
+  end
+
+  member_action :show_responses do
+    @survey_question = resource
+    render layout: "active_admin"
   end
 end

--- a/app/admin/survey_question.rb
+++ b/app/admin/survey_question.rb
@@ -1,0 +1,22 @@
+ActiveAdmin.register SurveyQuestion do
+  menu priority: 6
+
+  config.sort_order = "position_desc"
+
+  permit_params :prompt, :required,
+                options_attributes: [:id, :position, :value]
+
+  form do |f|
+    f.inputs do
+      f.input :prompt
+
+      f.has_many :options, label: "xyz", sortable: :position, allow_destroy: true do |o|
+        o.input :value
+      end
+
+      f.input :required
+    end
+
+    f.actions
+  end
+end

--- a/app/admin/survey_question.rb
+++ b/app/admin/survey_question.rb
@@ -30,7 +30,10 @@ ActiveAdmin.register SurveyQuestion do
       f.input :required
     end
 
-    survey_question.survey = "/feedback" if survey_question.new_record?
+    if survey_question.new_record?
+      survey_question.survey = Feedback::LONG_SURVEY
+    end
+
     f.input :survey, as: :hidden
 
     f.actions

--- a/app/admin/surveys.rb
+++ b/app/admin/surveys.rb
@@ -1,0 +1,24 @@
+ActiveAdmin.register_page "Surveys" do
+  menu(false)
+
+  controller do
+    def index
+      quick_questions = SurveyQuestion.order(:position).
+                        where(survey: Feedback::QUICK_SURVEY)
+
+      long_questions = SurveyQuestion.order(:position).
+                        where(survey: Feedback::LONG_SURVEY)
+
+      @surveys = {
+        "Quick Feedback" => quick_questions,
+        "Website Satisfaction" => long_questions
+      }
+
+      render layout: "active_admin"
+    end
+  end
+
+  content do
+    render template: "admin/surveys/index"
+  end
+end

--- a/app/assets/javascripts/application/feedback.js
+++ b/app/assets/javascripts/application/feedback.js
@@ -1,0 +1,11 @@
+$(document).on('click', '.quick-feedback .tab a', function(e) {
+  e.preventDefault();
+
+  $('.quick-feedback').toggleClass('closed');
+});
+
+$(document).on('click', function(e) {
+  if (!$(e.target).is('.quick-feedback, .quick-feedback *')) {
+    $('.quick-feedback').addClass('closed');
+  }
+});

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -99,3 +99,17 @@
     display: block;
   }
 }
+
+.show_responses {
+  h2 {
+    margin-bottom: 1.2rem;
+  }
+
+  table thead {
+    text-align: left;
+  }
+
+  table td {
+    padding-right: 2rem;
+  }
+}

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -102,14 +102,29 @@
 
 .show_responses {
   h2 {
-    margin-bottom: 1.2rem;
+    margin-bottom: 0.5rem;
+  }
+}
+
+table.histogram {
+  .frequent {
+    font-weight: bold;
   }
 
-  table thead {
-    text-align: left;
-  }
-
-  table td {
+  td {
     padding-right: 2rem;
+
+    &:last-child {
+      min-width: 240px;
+      display: flex;
+    }
+  }
+
+  .bar {
+    display: inline-block;
+    background-color: #386165;
+    margin-right: 0.3rem;
+    height: 1rem;
+    vertical-align: middle;
   }
 }

--- a/app/assets/stylesheets/admin/surveys.scss
+++ b/app/assets/stylesheets/admin/surveys.scss
@@ -1,0 +1,19 @@
+.admin_surveys .blank_slate {
+  display: block;
+  border: 0;
+
+  h2 {
+    font-size: 1.5rem;
+    margin: 0.7rem 0;
+  }
+
+  h3 {
+    font-size: 1rem;
+    font-weight: bold;
+    margin: 0.9rem 0 0;
+  }
+
+  hr {
+    margin: 1rem 0;
+  }
+}

--- a/app/assets/stylesheets/application/feedback.scss
+++ b/app/assets/stylesheets/application/feedback.scss
@@ -6,6 +6,14 @@
       margin-bottom: 0.5rem;
     }
 
+    &.with-errors p {
+      color: #f00;
+    }
+
+    .field_with_errors {
+      display: inline;
+    }
+
     .survey-option {
       margin-left: 1rem;
     }

--- a/app/assets/stylesheets/application/feedback.scss
+++ b/app/assets/stylesheets/application/feedback.scss
@@ -1,0 +1,19 @@
+.section-feedback {
+  .survey-question {
+    margin-bottom: 1rem;
+
+    p {
+      margin-bottom: 0.5rem;
+    }
+
+    .survey-option {
+      margin-left: 1rem;
+    }
+
+    textarea {
+      width: 100%;
+      max-width: 540px;
+      min-height: 120px;
+    }
+  }
+}

--- a/app/assets/stylesheets/application/feedback.scss
+++ b/app/assets/stylesheets/application/feedback.scss
@@ -1,4 +1,8 @@
 .section-feedback {
+  .side-feedback {
+    display: none;
+  }
+
   .survey-question {
     margin-bottom: 1rem;
 

--- a/app/assets/stylesheets/application/layout.scss
+++ b/app/assets/stylesheets/application/layout.scss
@@ -20,6 +20,109 @@
   display: none;
 }
 
+.side-feedback {
+  display: block;
+
+  .quick-feedback {
+    position: fixed;
+    right: 0;
+    top: 60%;
+    z-index: 1000;
+
+    display: flex;
+
+    &.closed .drawer {
+      margin-right: -20rem;
+    }
+
+    .drawer {
+      width: 20rem;
+      margin-right: 0;
+      transition: margin-right 200ms;
+    }
+  }
+
+  .tab a {
+    position: relative;
+    top: -1rem;
+
+    display: inline-block;
+    background-color: $light-teal;
+    text-transform: uppercase;
+    color: $dark-teal;
+    transform: rotate(-90deg);
+    transform-origin: right;
+    border-top-left-radius: 0.8rem;
+    border-top-right-radius: 0.8rem;
+    font-size: 0.8rem;
+    font-weight: bold;
+    margin-right: 1.05rem;
+    padding: 0.3rem 1.2rem;
+
+    text-decoration: none;
+  }
+
+  form {
+    border: 1px solid $light-teal;
+    padding: 0.5rem;
+    background-color: #fff;
+
+    font-size: 0.8rem;
+
+    .survey-question p {
+      color: $dark-teal;
+      font-weight: bold;
+    }
+
+    .survey-response {
+      display: flex;
+      align-items: flex-end;
+    }
+
+    .survey-option {
+      flex: 1;
+      max-height: 24px;
+      margin-bottom: 1.7rem;
+
+      &:not(:first-child) {
+        text-align: center;
+      }
+    }
+
+    .survey-option label {
+      border: 2px solid #000;
+      padding: 0.25rem 1.3rem;
+      cursor: pointer;
+    }
+
+    input[type=radio] {
+      width: 1px;
+      height: 1px;
+      clip: rect(1px, 1px, 1px, 1px);
+      position: absolute;
+      overflow: hidden;
+    }
+
+    input[type=radio]:checked + label {
+      background-color: $dark-teal;
+      color: #fff;
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 130px;
+      margin-bottom: 1rem;
+      padding: 0.4rem;
+    }
+  }
+
+  h1 {
+    font-size: 1.2rem;
+    line-height: 1.618;
+    margin-bottom: 0.7rem;
+  }
+}
+
 #main-content {
   position: relative;
   margin: 1rem 1rem 6rem;

--- a/app/assets/stylesheets/application/layout.scss
+++ b/app/assets/stylesheets/application/layout.scss
@@ -49,7 +49,7 @@
     display: inline-block;
     background-color: $light-teal;
     text-transform: uppercase;
-    color: $dark-teal;
+    color: $darkest-teal;
     transform: rotate(-90deg);
     transform-origin: right;
     border-top-left-radius: 0.8rem;
@@ -70,7 +70,7 @@
     font-size: 0.8rem;
 
     .survey-question p {
-      color: $dark-teal;
+      color: $darkest-teal;
       font-weight: bold;
     }
 

--- a/app/assets/stylesheets/application/layout.scss
+++ b/app/assets/stylesheets/application/layout.scss
@@ -54,7 +54,6 @@
     transform-origin: right;
     border-top-left-radius: 0.8rem;
     border-top-right-radius: 0.8rem;
-    font-size: 0.8rem;
     font-weight: bold;
     margin-right: 1.05rem;
     padding: 0.3rem 1.2rem;

--- a/app/assets/stylesheets/application/layout.scss
+++ b/app/assets/stylesheets/application/layout.scss
@@ -32,11 +32,11 @@
     display: flex;
 
     &.closed .drawer {
-      margin-right: -20rem;
+      margin-right: -18rem;
     }
 
     .drawer {
-      width: 20rem;
+      width: 18rem;
       margin-right: 0;
       transition: margin-right 200ms;
     }
@@ -83,10 +83,7 @@
       flex: 1;
       max-height: 24px;
       margin-bottom: 1.7rem;
-
-      &:not(:first-child) {
-        text-align: center;
-      }
+      text-align: center;
     }
 
     .survey-option label {

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,4 +1,6 @@
 class FeedbackController < ApplicationController
+  invisible_captcha only: :create
+
   def new
     @feedback = Feedback.new
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -35,7 +35,7 @@ class FeedbackController < ApplicationController
 
   def survey_questions
     SurveyQuestion.
-      where(survey: "/feedback").
+      where(survey: Feedback::LONG_SURVEY).
       order(:position).
       preload(:options)
   end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,7 +4,7 @@ class FeedbackController < ApplicationController
   def new
     @feedback = Feedback.new
 
-    SurveyQuestion.order(:position).preload(:options).each do |question|
+    survey_questions.each do |question|
       @feedback.survey_responses.build(survey_question: question)
     end
   end
@@ -27,5 +27,12 @@ class FeedbackController < ApplicationController
   def feedback_params
     params.require(:feedback).
       permit(survey_responses_attributes: [:survey_question_id, :value])
+  end
+
+  def survey_questions
+    SurveyQuestion.
+      where(survey: "/feedback").
+      order(:position).
+      preload(:options)
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,0 +1,27 @@
+class FeedbackController < ApplicationController
+  def new
+    @feedback = Feedback.new
+
+    SurveyQuestion.order(:position).preload(:options).each do |question|
+      @feedback.survey_responses.build(survey_question: question)
+    end
+  end
+
+  def create
+    if @feedback = Feedback.create(feedback_params)
+      redirect_to :feedback_thanks
+    else
+      render "new"
+    end
+  end
+
+  def thanks
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).
+      permit(survey_responses_attributes: [:survey_question_id, :value])
+  end
+end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -29,7 +29,8 @@ class FeedbackController < ApplicationController
 
   def feedback_params
     params.require(:feedback).
-      permit(survey_responses_attributes: [:survey_question_id, :value])
+      permit(survey_responses_attributes: [:survey_question_id, :value]).
+      merge(source_url: request.referrer)
   end
 
   def survey_questions

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -13,7 +13,7 @@ class FeedbackController < ApplicationController
     @feedback = Feedback.create(feedback_params)
 
     if @feedback.errors.any?
-      render "new"
+      render "feedback/new"
     else
       redirect_to :feedback_thanks
     end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -15,7 +15,10 @@ class FeedbackController < ApplicationController
     if @feedback.errors.any?
       render "feedback/new"
     else
-      redirect_to :feedback_thanks
+      respond_to do |format|
+        format.html{ redirect_to :feedback_thanks }
+        format.js
+      end
     end
   end
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -10,10 +10,12 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    if @feedback = Feedback.create(feedback_params)
-      redirect_to :feedback_thanks
-    else
+    @feedback = Feedback.create(feedback_params)
+
+    if @feedback.errors.any?
       render "new"
+    else
+      redirect_to :feedback_thanks
     end
   end
 

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,0 +1,8 @@
+module FeedbackHelper
+  def survey_prompt(question)
+    question.prompt.strip.tap do |prompt|
+      prompt << ":" unless prompt =~ /[.?!:]$/
+      prompt << "*" if question.required?
+    end
+  end
+end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -6,6 +6,22 @@ module FeedbackHelper
     end
   end
 
+  def survey_response_histogram(question)
+    table = question.options.order(:position).map do |option|
+      [option.value, question.responses.where(value: option.value).count]
+    end.to_h
+
+    total = table.values.sum
+    table.map do |option, count|
+      data = OpenStruct.new(
+        count: count,
+        percentage: 100.0 * count / total,
+        frequent?: table.values.all?{ |v| v <= count }
+      )
+      [option, data]
+    end.to_h
+  end
+
   def quick_feedback_responses
     questions = SurveyQuestion.
       where(survey: Feedback::QUICK_SURVEY).

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -5,4 +5,17 @@ module FeedbackHelper
       prompt << "*" if question.required?
     end
   end
+
+  def quick_feedback
+    Feedback.new.tap do |feedback|
+      questions = SurveyQuestion.
+        where(survey: "quick").
+        order(:position).
+        preload(:options)
+
+      questions.each do |question|
+        feedback.survey_responses.build(survey_question: question)
+      end
+    end
+  end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -6,16 +6,21 @@ module FeedbackHelper
     end
   end
 
-  def quick_feedback
-    Feedback.new.tap do |feedback|
-      questions = SurveyQuestion.
-        where(survey: Feedback::QUICK_SURVEY).
-        order(:position).
-        preload(:options)
+  def quick_feedback_responses
+    questions = SurveyQuestion.
+      where(survey: Feedback::QUICK_SURVEY).
+      order(:position).
+      preload(:options)
 
-      questions.each do |question|
-        feedback.survey_responses.build(survey_question: question)
-      end
+    questions.map do |question|
+      SurveyResponse.new(survey_question: question)
     end
+  end
+
+  def cache_key_for_quick_survey
+    # SurveyQuestion.where(survey: Feedback::QUICK_SURVEY).cache_key
+
+    # Let's just clear the cache whenever it changes...
+    "quick-survey"
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -9,7 +9,7 @@ module FeedbackHelper
   def quick_feedback
     Feedback.new.tap do |feedback|
       questions = SurveyQuestion.
-        where(survey: "quick").
+        where(survey: Feedback::QUICK_SURVEY).
         order(:position).
         preload(:options)
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,4 +1,4 @@
 class Feedback < ApplicationRecord
-  has_many :survey_responses
+  has_many :survey_responses, dependent: :destroy
   accepts_nested_attributes_for :survey_responses
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,4 +1,7 @@
 class Feedback < ApplicationRecord
   has_many :survey_responses, dependent: :destroy
   accepts_nested_attributes_for :survey_responses
+
+  QUICK_SURVEY = "quick".freeze
+  LONG_SURVEY = "/feedback".freeze
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,4 @@
+class Feedback < ApplicationRecord
+  has_many :survey_responses
+  accepts_nested_attributes_for :survey_responses
+end

--- a/app/models/survey_option.rb
+++ b/app/models/survey_option.rb
@@ -1,0 +1,2 @@
+class SurveyOption < ApplicationRecord
+end

--- a/app/models/survey_question.rb
+++ b/app/models/survey_question.rb
@@ -1,4 +1,6 @@
 class SurveyQuestion < ApplicationRecord
   has_many :options, class_name: "SurveyOption", dependent: :destroy
   accepts_nested_attributes_for :options
+
+  has_many :responses, class_name: "SurveyResponse"
 end

--- a/app/models/survey_question.rb
+++ b/app/models/survey_question.rb
@@ -1,0 +1,4 @@
+class SurveyQuestion < ApplicationRecord
+  has_many :options, class_name: "SurveyOption", dependent: :destroy
+  accepts_nested_attributes_for :options
+end

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -1,4 +1,6 @@
 class SurveyResponse < ApplicationRecord
   belongs_to :feedback
   belongs_to :survey_question
+
+  validates_presence_of :value, if: ->{ survey_question.required? }
 end

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -3,4 +3,12 @@ class SurveyResponse < ApplicationRecord
   belongs_to :survey_question
 
   validates_presence_of :value, if: ->{ survey_question.required? }
+
+  before_create :copy_prompt_from_question
+
+  private
+
+  def copy_prompt_from_question
+    self.prompt = survey_question.prompt
+  end
 end

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -1,0 +1,4 @@
+class SurveyResponse < ApplicationRecord
+  belongs_to :feedback
+  belongs_to :survey_question
+end

--- a/app/views/admin/feedback/show.html.erb
+++ b/app/views/admin/feedback/show.html.erb
@@ -7,7 +7,7 @@
 
   <% @feedback.survey_responses.each_with_index do |response, i| %>
     <div class="survey-response">
-      <p><%= i + 1 %>) <%= response.survey_question.prompt %></p>
+      <p><%= i + 1 %>) <%= response.prompt %></p>
 
       <blockquote><%= response.value %></blockquote>
     </div>

--- a/app/views/admin/feedback/show.html.erb
+++ b/app/views/admin/feedback/show.html.erb
@@ -1,0 +1,15 @@
+<div class="panel input">
+  <h2>
+    <strong>
+      Feedback from <%= @feedback.created_at.strftime('%b %d, %Y') %>
+    </strong>
+  </h2>
+
+  <% @feedback.survey_responses.each_with_index do |response, i| %>
+    <div class="survey-response">
+      <p><%= i + 1 %>) <%= response.survey_question.prompt %></p>
+
+      <blockquote><%= response.value %></blockquote>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/feedback/show.html.erb
+++ b/app/views/admin/feedback/show.html.erb
@@ -1,9 +1,11 @@
 <div class="panel input">
   <h2>
     <strong>
-      Feedback from <%= @feedback.created_at.strftime('%b %d, %Y') %>
+      Feedback on <%= @feedback.created_at.strftime('%b %d, %Y') %>
     </strong>
   </h2>
+
+  <p>From <%= link_to @feedback.source_url, @feedback.source_url %></p>
 
   <% @feedback.survey_responses.each_with_index do |response, i| %>
     <div class="survey-response">

--- a/app/views/admin/survey_questions/_histogram.html.erb
+++ b/app/views/admin/survey_questions/_histogram.html.erb
@@ -1,0 +1,11 @@
+<table class="histogram">
+  <% survey_response_histogram(survey_question).each do |option, data| %>
+    <tr class="<%= "frequent" if data.frequent? %>">
+      <td><%= option %></td>
+      <td>
+        <div class="bar" style="flex-basis: <%= data.percentage %>%"></div>
+        <div class="count"><%= data.count %></div>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/survey_questions/_survey_question.html.erb
+++ b/app/views/admin/survey_questions/_survey_question.html.erb
@@ -1,0 +1,24 @@
+<h3><%= survey_prompt(survey_question) %></h3>
+
+<% if survey_question.options.present? %>
+  <%= render "admin/survey_questions/histogram",
+             survey_question: survey_question %>
+<% else %>
+  <% survey_question.responses.order(created_at: :desc).limit(3).each do |response| %>
+    <% next unless response.value? %>
+
+    <blockquote>
+      <%= response.value %>
+      <br />
+
+      &mdash; <%= link_to response.feedback.created_at.strftime('%b %d, %Y'), "/admin/feedback/#{response.feedback.id}" %>
+      from <%= link_to response.feedback.source_url, response.feedback.source_url %>
+    </blockquote>
+  <% end %>
+
+  <% if survey_question.responses.size > 3 %>
+    <%= link_to ".. read all responses",
+          show_responses_admin_survey_question_path(survey_question) %>
+  <% end %>
+<% end %>
+

--- a/app/views/admin/survey_questions/show_responses.html.erb
+++ b/app/views/admin/survey_questions/show_responses.html.erb
@@ -1,0 +1,27 @@
+<div class="panel input">
+  <h2><strong><%= survey_prompt(@survey_question) %></strong></h2>
+
+  <% if @survey_question.options.present? %>
+    <table>
+      <thead><tr><th>Option</th><th>Responses</th></thead>
+
+      <% @survey_question.options.each do |option| %>
+        <tr>
+          <td><%= option.value %></td>
+          <td><%= @survey_question.responses.where(value: option.value).count %></td>
+        </tr>
+      <% end %>
+    </table>
+  <% else %>
+     <% @survey_question.responses.each do |response| %>
+       <% next unless response.value? %>
+
+       <blockquote>
+         <%= response.value %>
+         <br />
+
+         &mdash; Feedback from <%= link_to response.feedback.created_at.strftime('%b %d, %Y'), "/admin/feedback/#{response.feedback.id}" %>
+       </blockquote>
+     <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/survey_questions/show_responses.html.erb
+++ b/app/views/admin/survey_questions/show_responses.html.erb
@@ -2,16 +2,7 @@
   <h2><strong><%= survey_prompt(@survey_question) %></strong></h2>
 
   <% if @survey_question.options.present? %>
-    <table>
-      <thead><tr><th>Option</th><th>Responses</th></thead>
-
-      <% @survey_question.options.each do |option| %>
-        <tr>
-          <td><%= option.value %></td>
-          <td><%= @survey_question.responses.where(value: option.value).count %></td>
-        </tr>
-      <% end %>
-    </table>
+    <%= render "histogram", survey_question: @survey_question %>
   <% else %>
      <% @survey_question.responses.each do |response| %>
        <% next unless response.value? %>

--- a/app/views/admin/survey_questions/show_responses.html.erb
+++ b/app/views/admin/survey_questions/show_responses.html.erb
@@ -20,7 +20,8 @@
          <%= response.value %>
          <br />
 
-         &mdash; Feedback from <%= link_to response.feedback.created_at.strftime('%b %d, %Y'), "/admin/feedback/#{response.feedback.id}" %>
+         &mdash; <%= link_to response.feedback.created_at.strftime('%b %d, %Y'), "/admin/feedback/#{response.feedback.id}" %>
+         from <%= link_to response.feedback.source_url, response.feedback.source_url %>
        </blockquote>
      <% end %>
   <% end %>

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -1,0 +1,12 @@
+<div class="blank_slate">
+  <% @surveys.each do |name, questions| %>
+    <h2><%= name %> Survey</h2>
+
+    <% questions.each do |question| %>
+      <%= render "admin/survey_questions/survey_question",
+                 survey_question: question %>
+    <% end %>
+
+    <hr />
+  <% end %>
+</div>

--- a/app/views/feedback/create.html.erb
+++ b/app/views/feedback/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Feedback#create</h1>
+<p>Find me in app/views/feedback/create.html.erb</p>

--- a/app/views/feedback/create.js.erb
+++ b/app/views/feedback/create.js.erb
@@ -1,1 +1,1 @@
-$('#new_feedback').html("<%= j render(template: 'feedback/thanks') %>");
+$('#new_feedback').addClass('success').html("<%= j render(template: 'feedback/thanks') %>");

--- a/app/views/feedback/create.js.erb
+++ b/app/views/feedback/create.js.erb
@@ -1,0 +1,1 @@
+$('#new_feedback').html("<%= j render(template: 'feedback/thanks') %>");

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -12,6 +12,8 @@
   <p>* Indicates required field</p>
 
   <%= form_for(@feedback, url: feedback_create_path) do |f| %>
+    <%= invisible_captcha %>
+
     <%= f.fields_for(:survey_responses) do |sf| %>
       <%= sf.hidden_field :survey_question_id %>
 

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -17,7 +17,7 @@
     <%= f.fields_for(:survey_responses) do |sf| %>
       <%= sf.hidden_field :survey_question_id %>
 
-      <div class="survey-question">
+      <div class="survey-question <%= "with-errors" if sf.object.errors.any? %>">
         <p>
           <%= sf.options[:child_index] + 1 %>)
           <%= survey_prompt(sf.object.survey_question) %>
@@ -26,7 +26,7 @@
         <div class="survey-response">
           <% sf.object.survey_question.options.each do |option| %>
             <div class="survey-option">
-              <%= sf.radio_button :value, option.value %>
+              <%= sf.radio_button :value, option.value, required: sf.object.survey_question.required? %>
               <%= sf.label :value, option.value, value: option.value %>
             </div>
           <% end %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,0 +1,41 @@
+<div class="row">
+  <h1>SEC Website Satisfaction Survey</h1>
+
+  <p>
+    Please tell us what you think about SEC. Your thoughts will help us help you make your teaching experience impactful. Thank you!
+  </p>
+
+  <h2>Survey questions</h2>
+
+  <p>Please rate your level of satisfaction with the following aspects of our site:</p>
+
+  <p>* Indicates required field</p>
+
+  <%= form_for(@feedback, url: feedback_create_path) do |f| %>
+    <%= f.fields_for(:survey_responses) do |sf| %>
+      <%= sf.hidden_field :survey_question_id %>
+
+      <div class="survey-question">
+        <p>
+          <%= sf.options[:child_index] + 1 %>)
+          <%= survey_prompt(sf.object.survey_question) %>
+        </p>
+
+        <div class="survey-response">
+          <% sf.object.survey_question.options.each do |option| %>
+            <div class="survey-option">
+              <%= sf.radio_button :value, option.value %>
+              <%= sf.label :value, option.value, value: option.value %>
+            </div>
+          <% end %>
+
+          <% unless sf.object.survey_question.options.present? %>
+            <%= sf.text_area :value %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= f.submit "Submit", data: { disable_with: false } %>
+  <% end %>
+</div>

--- a/app/views/feedback/thanks.html.erb
+++ b/app/views/feedback/thanks.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+  <h1>Thanks!</h1>
+
+  <p>Thank you for providing feedback on your experience with EFF's Security Education Companion.</p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,8 +26,8 @@
       <%= render "shared/share", show_for: "medium" %>
     </div>
 
-    <div class="side-feedback">
-      <%= render "shared/feedback", show_for: "medium" %>
+    <div class="side-feedback show-for-medium">
+      <%= render "shared/feedback" %>
     </div>
 
     <div id="main-content">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,10 @@
       <%= render "shared/share", show_for: "medium" %>
     </div>
 
+    <div class="side-feedback">
+      <%= render "shared/feedback", show_for: "medium" %>
+    </div>
+
     <div id="main-content">
       <%= yield %>
     </div>

--- a/app/views/shared/_feedback.html.erb
+++ b/app/views/shared/_feedback.html.erb
@@ -4,30 +4,32 @@
   </div>
 
   <div class="drawer">
-    <%= form_for(quick_feedback, remote: true, url: feedback_create_path) do |f| %>
+    <%= form_for(Feedback.new, remote: true, url: feedback_create_path) do |f| %>
       <%= invisible_captcha %>
 
-      <%= f.fields_for(:survey_responses) do |sf| %>
-        <%= sf.hidden_field :survey_question_id %>
+      <%= cache(cache_key_for_quick_survey) do %>
+        <%= f.fields_for(:survey_responses, quick_feedback_responses) do |sf| %>
+          <%= sf.hidden_field :survey_question_id %>
 
-        <div class="survey-question <%= "with-errors" if sf.object.errors.any? %>">
-          <% if sf.object.survey_question.options.present? %>
-            <p><%= survey_prompt(sf.object.survey_question) %></p>
-          <% end %>
-
-          <div class="survey-response">
-            <% sf.object.survey_question.options.each do |option| %>
-              <div class="survey-option">
-                <%= sf.radio_button :value, option.value, required: sf.object.survey_question.required? %>
-                <%= sf.label :value, option.value, value: option.value %>
-              </div>
+          <div class="survey-question <%= "with-errors" if sf.object.errors.any? %>">
+            <% if sf.object.survey_question.options.present? %>
+              <p><%= survey_prompt(sf.object.survey_question) %></p>
             <% end %>
 
-            <% unless sf.object.survey_question.options.present? %>
-              <%= sf.text_area :value, placeholder: sf.object.survey_question.prompt %>
-            <% end %>
+            <div class="survey-response">
+              <% sf.object.survey_question.options.each do |option| %>
+                <div class="survey-option">
+                  <%= sf.radio_button :value, option.value, required: sf.object.survey_question.required? %>
+                  <%= sf.label :value, option.value, value: option.value %>
+                </div>
+              <% end %>
+
+              <% unless sf.object.survey_question.options.present? %>
+                <%= sf.text_area :value, placeholder: sf.object.survey_question.prompt %>
+              <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
 
       <%= f.submit "Send feedback", data: { disable_with: false } %>

--- a/app/views/shared/_feedback.html.erb
+++ b/app/views/shared/_feedback.html.erb
@@ -1,0 +1,36 @@
+<div class="quick-feedback closed">
+  <div class="tab">
+    <%= link_to "Feedback", feedback_root_path %>
+  </div>
+
+  <div class="drawer">
+    <%= form_for(quick_feedback, remote: true, url: feedback_create_path) do |f| %>
+      <%= invisible_captcha %>
+
+      <%= f.fields_for(:survey_responses) do |sf| %>
+        <%= sf.hidden_field :survey_question_id %>
+
+        <div class="survey-question <%= "with-errors" if sf.object.errors.any? %>">
+          <% if sf.object.survey_question.options.present? %>
+            <p><%= survey_prompt(sf.object.survey_question) %></p>
+          <% end %>
+
+          <div class="survey-response">
+            <% sf.object.survey_question.options.each do |option| %>
+              <div class="survey-option">
+                <%= sf.radio_button :value, option.value, required: sf.object.survey_question.required? %>
+                <%= sf.label :value, option.value, value: option.value %>
+              </div>
+            <% end %>
+
+            <% unless sf.object.survey_question.options.present? %>
+              <%= sf.text_area :value, placeholder: sf.object.survey_question.prompt %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <%= f.submit "Send feedback", data: { disable_with: false } %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -302,7 +302,7 @@ ActiveAdmin.setup do |config|
     end
 
     admin.build_menu do |menu|
-      menu.add label: "Surveys", priority: 6 do |surveys|
+      menu.add label: "Surveys", priority: 6, url: "/admin/surveys" do |surveys|
         surveys.add label: "Quick Survey",
           url: "/admin/survey_questions?q%5Bsurvey_equals%5D=quick",
           priority: 1

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -300,5 +300,17 @@ ActiveAdmin.setup do |config|
     admin.build_menu do |menu|
       menu.add label: "Pages", priority: 2
     end
+
+    admin.build_menu do |menu|
+      menu.add label: "Surveys", priority: 6 do |surveys|
+        surveys.add label: "Quick Survey",
+          url: "/admin/survey_questions?q%5Bsurvey_equals%5D=quick",
+          priority: 1
+
+        surveys.add label: "Website Satisfaction",
+          url: "/admin/survey_questions?q%5Bsurvey_equals%5D=/feedback",
+          priority: 2
+      end
+    end
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -310,6 +310,10 @@ ActiveAdmin.setup do |config|
         surveys.add label: "Website Satisfaction",
           url: "/admin/survey_questions?q%5Bsurvey_equals%5D=/feedback",
           priority: 2
+
+        surveys.add label: "Browse Feedback",
+          url: "/admin/feedback", priority: 3,
+          html_options: { style: "border-top: 1px dashed gray; margin-top: 4px; padding-top: 8px;" }
       end
     end
   end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.plural "feedback", "feedback"
+  inflect.plural "Feedback", "Feedback"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,12 @@ Rails.application.routes.draw do
 
   resources :glossary, only: [:index, :show]
 
+  scope "/feedback", as: :feedback, controller: "feedback" do
+    root action: :new
+    post :create
+    get :thanks
+  end
+
   get "/credits", as: :credits, to: "credits#index"
   get "/search", as: :search, to: "search#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   scope "/feedback", as: :feedback, controller: "feedback" do
     root action: :new
-    post :create
+    post "/", action: :create, as: :create
     get :thanks
   end
 

--- a/db/migrate/20180226190337_create_survey_questions.rb
+++ b/db/migrate/20180226190337_create_survey_questions.rb
@@ -1,0 +1,11 @@
+class CreateSurveyQuestions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :survey_questions do |t|
+      t.integer :position, null: false, default: 0
+      t.string :prompt, null: false
+      t.boolean :required, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180226191155_create_survey_options.rb
+++ b/db/migrate/20180226191155_create_survey_options.rb
@@ -1,0 +1,11 @@
+class CreateSurveyOptions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :survey_options do |t|
+      t.integer :survey_question_id, null: false
+      t.integer :position, null: false, default: 0
+      t.string :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180226193300_create_feedback.rb
+++ b/db/migrate/20180226193300_create_feedback.rb
@@ -1,0 +1,7 @@
+class CreateFeedback < ActiveRecord::Migration[5.1]
+  def change
+    create_table :feedback do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180226193508_create_survey_responses.rb
+++ b/db/migrate/20180226193508_create_survey_responses.rb
@@ -3,7 +3,7 @@ class CreateSurveyResponses < ActiveRecord::Migration[5.1]
     create_table :survey_responses do |t|
       t.integer :feedback_id, null: false
       t.integer :survey_question_id, null: false
-      t.text :value, null: false
+      t.text :value
 
       t.timestamps
     end

--- a/db/migrate/20180226193508_create_survey_responses.rb
+++ b/db/migrate/20180226193508_create_survey_responses.rb
@@ -1,0 +1,11 @@
+class CreateSurveyResponses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :survey_responses do |t|
+      t.integer :feedback_id, null: false
+      t.integer :survey_question_id, null: false
+      t.text :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
+++ b/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
@@ -5,7 +5,7 @@ class AddPromptToSurveyResponses < ActiveRecord::Migration[5.1]
     reversible do |dir|
       dir.up do
         SurveyResponse.all.find_each do |response|
-          response.prompt ||= response.survey_question.prompt
+          response.prompt = response.survey_question.prompt
           response.save
         end
       end

--- a/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
+++ b/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
@@ -1,0 +1,14 @@
+class AddPromptToSurveyResponses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :survey_responses, :prompt, :string, null: false
+
+    reversible do |dir|
+      dir.up do
+        SurveyResponse.all.find_each do |response|
+          response.prompt ||= response.survey_question.prompt
+          response.save
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
+++ b/db/migrate/20180227001325_add_prompt_to_survey_responses.rb
@@ -1,6 +1,6 @@
 class AddPromptToSurveyResponses < ActiveRecord::Migration[5.1]
   def change
-    add_column :survey_responses, :prompt, :string, null: false
+    add_column :survey_responses, :prompt, :string, null: false, default: ""
 
     reversible do |dir|
       dir.up do

--- a/db/migrate/20180227185715_add_survey_to_survey_questions.rb
+++ b/db/migrate/20180227185715_add_survey_to_survey_questions.rb
@@ -4,7 +4,7 @@ class AddSurveyToSurveyQuestions < ActiveRecord::Migration[5.1]
 
     reversible do |dir|
       dir.up do
-        SurveyQuestion.update_all(survey: "/feedback")
+        SurveyQuestion.update_all(survey: Feedback::LONG_SURVEY)
       end
     end
   end

--- a/db/migrate/20180227185715_add_survey_to_survey_questions.rb
+++ b/db/migrate/20180227185715_add_survey_to_survey_questions.rb
@@ -1,0 +1,11 @@
+class AddSurveyToSurveyQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :survey_questions, :survey, :string, null: false, default: ""
+
+    reversible do |dir|
+      dir.up do
+        SurveyQuestion.update_all(survey: "/feedback")
+      end
+    end
+  end
+end

--- a/db/migrate/20180227191704_create_quick_survey.rb
+++ b/db/migrate/20180227191704_create_quick_survey.rb
@@ -1,0 +1,21 @@
+class CreateQuickSurvey < ActiveRecord::Migration[5.1]
+  def up
+    q = SurveyQuestion.create(
+      survey: "quick",
+      prompt: "Did you find what you were looking for?"
+    )
+
+    q.options << SurveyOption.new(value: "Yes")
+    q.options << SurveyOption.new(value: "Partially")
+    q.options << SurveyOption.new(value: "No")
+
+    SurveyQuestion.create(
+      survey: "quick",
+      prompt: "Share what you like best or what could we do to improve Security Education"
+    )
+  end
+
+  def down
+    SurveyQuestion.where(survey: "quick").destroy_all
+  end
+end

--- a/db/migrate/20180227191704_create_quick_survey.rb
+++ b/db/migrate/20180227191704_create_quick_survey.rb
@@ -1,7 +1,7 @@
 class CreateQuickSurvey < ActiveRecord::Migration[5.1]
   def up
     q = SurveyQuestion.create(
-      survey: "quick",
+      survey: Feedback::QUICK_SURVEY,
       prompt: "Did you find what you were looking for?"
     )
 
@@ -10,7 +10,7 @@ class CreateQuickSurvey < ActiveRecord::Migration[5.1]
     q.options << SurveyOption.new(value: "No")
 
     SurveyQuestion.create(
-      survey: "quick",
+      survey: Feedback::QUICK_SURVEY,
       prompt: "Share what you like best or what could we do to improve Security Education"
     )
   end

--- a/db/migrate/20180227230110_add_source_url_to_feedback.rb
+++ b/db/migrate/20180227230110_add_source_url_to_feedback.rb
@@ -1,0 +1,5 @@
+class AddSourceUrlToFeedback < ActiveRecord::Migration[5.1]
+  def change
+    add_column :feedback, :source_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180214003707) do
+ActiveRecord::Schema.define(version: 20180226193508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,11 @@ ActiveRecord::Schema.define(version: 20180214003707) do
     t.index ["content_type", "content_id"], name: "index_featured_content_on_content_type_and_content_id"
   end
 
+  create_table "feedback", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
@@ -233,6 +238,30 @@ ActiveRecord::Schema.define(version: 20180214003707) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
+  end
+
+  create_table "survey_options", force: :cascade do |t|
+    t.integer "survey_question_id", null: false
+    t.integer "position", default: 0, null: false
+    t.string "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "survey_questions", force: :cascade do |t|
+    t.integer "position", default: 0, null: false
+    t.string "prompt", null: false
+    t.boolean "required", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "survey_responses", force: :cascade do |t|
+    t.integer "feedback_id", null: false
+    t.integer "survey_question_id", null: false
+    t.text "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -263,7 +263,7 @@ ActiveRecord::Schema.define(version: 20180227191704) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "prompt", null: false, default: ""
+    t.string "prompt"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227191704) do
+ActiveRecord::Schema.define(version: 20180227230110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 20180227191704) do
   create_table "feedback", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source_url"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227001325) do
+ActiveRecord::Schema.define(version: 20180227191704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -254,6 +254,7 @@ ActiveRecord::Schema.define(version: 20180227001325) do
     t.boolean "required", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "survey", default: "", null: false
   end
 
   create_table "survey_responses", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226193508) do
+ActiveRecord::Schema.define(version: 20180227001325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,7 @@ ActiveRecord::Schema.define(version: 20180226193508) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "prompt", null: false
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -259,7 +259,7 @@ ActiveRecord::Schema.define(version: 20180226193508) do
   create_table "survey_responses", force: :cascade do |t|
     t.integer "feedback_id", null: false
     t.integer "survey_question_id", null: false
-    t.text "value", null: false
+    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 20180227001325) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "prompt", null: false
+    t.string "prompt", null: false, default: ""
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/spec/features/give_feedback_spec.rb
+++ b/spec/features/give_feedback_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.feature "GiveFeedback", type: :feature, js: true do
+  let(:article) { FactoryGirl.create(:article) }
+
+  let(:quick_questions) {
+    SurveyQuestion.where(survey: Feedback::QUICK_SURVEY)
+  }
+
+  let(:survey_questions) {
+    SurveyQuestion.where(survey: Feedback::LONG_SURVEY)
+  }
+
+  before do
+    quick_questions.create(
+      prompt: "Did you find what you were looking for?",
+      options_attributes: [{ value: "Yes" },
+                           { value: "Partially" },
+                           { value: "No" }]
+    )
+
+    quick_questions.create(prompt: "Any comments?")
+
+    survey_questions.create(
+      prompt: "What is your overall impression?",
+      options_attributes: [{ value: "Satisfied" },
+                           { value: "Neutral" },
+                           { value: "Dissatisfied" }],
+      required: true
+    )
+
+    survey_questions.create(
+      prompt: "What best describes your affiliation?"
+    )
+  end
+
+  scenario "user fills in the quick feedback form" do
+    visit article_path(article)
+    source_url = current_url
+
+    click_on("Feedback")
+
+    within(:css, ".quick-feedback") do
+      find(:css, "label[for=feedback_survey_responses_attributes_0_value_partially]").click
+      find(:css, "textarea").send_keys("These are my comments.")
+
+      expect {
+        click_on("Send feedback")
+        has_css?("#new_feedback.success")
+      }.to change(Feedback, :count).by(1)
+
+      feedback = Feedback.order(id: :desc).take
+      expect(feedback.survey_responses.pluck(:value)).
+        to eq(["Partially", "These are my comments."])
+
+      expect(feedback.source_url).to eq(source_url)
+    end
+  end
+
+  scenario "user fills in the long feedback form" do
+    visit feedback_root_path
+    source_url = current_url
+
+    choose "Neutral"
+    find(:css, "textarea").send_keys("I am a teacher.")
+
+    expect {
+      click_on("Submit")
+      has_current_path?(feedback_thanks_path)
+    }.to change(Feedback, :count).by(1)
+
+    feedback = Feedback.order(id: :desc).take
+
+    expect(feedback.survey_responses.pluck(:value)).
+      to eq(["Neutral", "I am a teacher."])
+
+    expect(feedback.source_url).to eq(source_url)
+  end
+end

--- a/spec/support/invisible_captcha.rb
+++ b/spec/support/invisible_captcha.rb
@@ -1,0 +1,4 @@
+# Don't prevent form fills by bots during the test run
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = false
+end


### PR DESCRIPTION
Adds a page at /feedback with a user satisfaction survey. Also adds a little drawer on the right side of the page for users to submit quick feedback on the current page.

Manage the /feedback survey questions at /admin/survey_questions?q%5Bsurvey_equals%5D=/feedback. Technically these should be reorderable but that isn't implemented yet...