### PR TITLE
Hide feedback widget until survey is finalized

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -25,7 +25,7 @@
     </ul>
 
     <ul class="about">
-      <li><%= link_to "Contact", feedback_root_path %></li>
+      <li><%= link_to "Contact", "mailto:sec-feedback@eff.org" %></li>
       <li><%= link_to "Credits", "/credits" %></li>
       <li><%= link_to "Privacy", "https://www.eff.org/policy" %></li>
       <li><%= link_to "License", "https://www.eff.org/copyright" %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     </div>
 
     <div class="side-feedback show-for-medium">
-      <%= render "shared/feedback" %>
+      <%= render "shared/feedback" if current_admin_user %>
     </div>
 
     <div id="main-content">

--- a/spec/features/give_feedback_spec.rb
+++ b/spec/features/give_feedback_spec.rb
@@ -35,6 +35,9 @@ RSpec.feature "GiveFeedback", type: :feature, js: true do
   end
 
   scenario "user fills in the quick feedback form" do
+    # Remove once surveys become live.
+    login(FactoryGirl.create(:admin_user))
+
     visit article_path(article)
     source_url = current_url
 


### PR DESCRIPTION
This branch hides the front end for feedback surveys (except to admins), since the questions haven't been thought up yet.