### PR TITLE
Add pdf format for lesson plans

### DIFF
--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -191,3 +191,7 @@ ul, ol {
 h1 {
   margin-bottom: 1rem;
 }
+
+.page-break {
+  page-break-before: always;
+}

--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -185,7 +185,7 @@ table {
 
 
 ul, ol {
-  margin-left: 3rem;
+  margin-left: 1.6rem;
 }
 
 h1 {

--- a/app/controllers/lesson_plans_controller.rb
+++ b/app/controllers/lesson_plans_controller.rb
@@ -11,6 +11,15 @@ class LessonPlansController < ApplicationController
 
     respond_to do |format|
       format.html
+      format.pdf do
+        if Rails.env.development?
+          @lesson_plan.recreate_pdf_file
+          send_file(@lesson_plan.pdf.path, disposition: "inline")
+        else
+          redirect_to @lesson_plan.pdf.url
+        end
+      end
+
       format.zip do
         files = @lesson_plan_lessons.map(&:lesson).map(&:pdf)
 

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -1,0 +1,5 @@
+module PdfHelper
+  def page_break
+    content_tag(:div, "", class: "page-break")
+  end
+end

--- a/app/jobs/update_lesson_pdf.rb
+++ b/app/jobs/update_lesson_pdf.rb
@@ -1,35 +1,16 @@
+require_dependency "pdf_template"
+
 class UpdateLessonPdf < ApplicationJob
   queue_as :pdfs
 
   def perform(lesson_id)
     lesson = Lesson.find(lesson_id)
 
-    controller = LessonsController.new
-    controller.instance_variable_set("@topic", lesson.topic)
-    controller.instance_variable_set("@lesson", lesson)
-
-    doc = controller.render_to_string(
-      template: "lessons/show.pdf.erb",
-      layout: "layouts/pdf.html.erb"
+    pdf = PdfTemplate.new(
+      name: lesson.topic.name,
+      template: "lessons/show.pdf.erb"
     )
 
-    pdf = WickedPdf.new.pdf_from_string(
-      doc,
-      pdf: lesson.topic.name,
-      margin: {
-        top: "1in",
-        bottom: "1in",
-        left: "1in",
-        right: "1in"
-      }
-    )
-
-    tmp = Tempfile.new(["lesson", ".pdf"])
-    tmp.binmode
-    tmp.write(pdf)
-    tmp.flush
-    tmp.rewind
-
-    lesson.update!(pdf: tmp)
+    lesson.update!(pdf: pdf.render(topic: lesson.topic, lesson: lesson))
   end
 end

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -1,4 +1,5 @@
 require_dependency "duration"
+require_dependency "pdf_template"
 
 class LessonPlan < ApplicationRecord
   has_many :lesson_plan_lessons,
@@ -23,32 +24,13 @@ class LessonPlan < ApplicationRecord
   end
 
   def recreate_pdf_file
-    controller = LessonPlansController.new
-    controller.instance_variable_set("@lesson_plan", self)
-
-    doc = controller.render_to_string(
-      template: "lesson_plans/show.pdf.erb",
-      layout: "layouts/pdf.html.erb"
+    pdf = PdfTemplate.new(
+      name: "Lesson Plan",
+      template: "lesson_plans/show.pdf.erb"
     )
 
-    pdf = WickedPdf.new.pdf_from_string(
-      doc,
-      pdf: "Lesson Plan",
-      margin: {
-        top: "0.6in",
-        bottom: "1in",
-        left: "1in",
-        right: "0.6in"
-      }
-    )
-
-    tmp = Tempfile.new(["lesson_plan", ".pdf"])
-    tmp.binmode
-    tmp.write(pdf)
-    tmp.flush
-    tmp.rewind
-
-    update!(pdf_file: tmp, pdf_file_updated_at: Time.now)
+    update!(pdf_file: pdf.render(lesson_plan: self),
+            pdf_file_updated_at: Time.now)
   end
 
   def pdf_file_filename

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -2,8 +2,7 @@ require_dependency "duration"
 
 class LessonPlan < ApplicationRecord
   has_many :lesson_plan_lessons,
-           after_add: ->(plan, _){ plan.update(pdf_file_updated_at: nil) },
-           after_remove: ->(plan, _){ plan.update(pdf_file_updated_at: nil) }
+           after_remove: ->(plan, _){ plan.update_column(:pdf_file_updated_at, nil) }
 
   has_many :lessons, through: :lesson_plan_lessons
 

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -2,8 +2,8 @@ require_dependency "duration"
 
 class LessonPlan < ApplicationRecord
   has_many :lesson_plan_lessons,
-           after_add: ->{ update(pdf_file_updated_at: nil) },
-           after_remove: ->{ update(pdf_file_updated_at: nil) }
+           after_add: ->(plan, _){ plan.update(pdf_file_updated_at: nil) },
+           after_remove: ->(plan, _){ plan.update(pdf_file_updated_at: nil) }
 
   has_many :lessons, through: :lesson_plan_lessons
 

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -1,13 +1,61 @@
 require_dependency "duration"
 
 class LessonPlan < ApplicationRecord
-  has_many :lesson_plan_lessons
+  has_many :lesson_plan_lessons,
+           after_add: ->{ update(pdf_file_updated_at: nil) },
+           after_remove: ->{ update(pdf_file_updated_at: nil) }
+
   has_many :lessons, through: :lesson_plan_lessons
 
-  accepts_nested_attributes_for :lesson_plan_lessons, allow_destroy: true
+  accepts_nested_attributes_for :lesson_plan_lessons,
+                                allow_destroy: true
 
   validates_uniqueness_of :key
   before_validation :set_key, on: :create
+
+  mount_uploader :pdf_file, GenericUploader
+
+  def pdf
+    unless pdf_file_updated_at.try(:>=, lessons.pluck(:updated_at).max)
+      self.recreate_pdf_file
+    end
+
+    pdf_file
+  end
+
+  def recreate_pdf_file
+    controller = LessonPlansController.new
+    controller.instance_variable_set("@lesson_plan", self)
+
+    doc = controller.render_to_string(
+      template: "lesson_plans/show.pdf.erb",
+      layout: "layouts/pdf.html.erb"
+    )
+
+    pdf = WickedPdf.new.pdf_from_string(
+      doc,
+      pdf: "Lesson Plan",
+      margin: {
+        top: "0.6in",
+        bottom: "1in",
+        left: "1in",
+        right: "0.6in"
+      }
+    )
+
+    tmp = Tempfile.new(["lesson_plan", ".pdf"])
+    tmp.binmode
+    tmp.write(pdf)
+    tmp.flush
+    tmp.rewind
+
+    update!(pdf_file: tmp, pdf_file_updated_at: Time.now)
+    reload
+  end
+
+  def pdf_file_filename
+    "Lesson Plan.pdf"
+  end
 
   def duration
     Duration.new(lessons.sum :duration)

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -50,7 +50,6 @@ class LessonPlan < ApplicationRecord
     tmp.rewind
 
     update!(pdf_file: tmp, pdf_file_updated_at: Time.now)
-    reload
   end
 
   def pdf_file_filename

--- a/app/uploaders/generic_uploader.rb
+++ b/app/uploaders/generic_uploader.rb
@@ -1,0 +1,19 @@
+class GenericUploader < CarrierWave::Uploader::Base
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    base = Rails.env.test? ? "/tmp/sec-test" : "uploads/"
+    "#{base}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def extension_whitelist
+    %w(pdf)
+  end
+
+  def filename
+    model.send("#{mounted_as}_filename")
+  end
+end

--- a/app/views/lesson_plans/show.pdf.erb
+++ b/app/views/lesson_plans/show.pdf.erb
@@ -1,0 +1,13 @@
+<h1>Lesson Plan:</h1>
+
+<% @lesson_plan.lessons.each_with_index do |lesson, ilesson| %>
+  <%= ilesson + 1 %>. <%= lesson.name %> (<%= lesson.duration.in_words %>)<br />
+<% end %>
+
+<p>Total duration: <%= @lesson_plan.duration.in_words %></p>
+
+<% @lesson_plan.lessons.each do |lesson| %>
+  <%= page_break %>
+  <% @topic, @lesson = lesson.topic, lesson %>
+  <%= render template: "lessons/show" %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.watchable_files.concat Dir[Rails.root.join("lib/*.rb")]
 end

--- a/db/migrate/20180328223103_add_pdf_file_to_lesson_plans.rb
+++ b/db/migrate/20180328223103_add_pdf_file_to_lesson_plans.rb
@@ -1,0 +1,6 @@
+class AddPdfFileToLessonPlans < ActiveRecord::Migration[5.1]
+  def change
+    add_column :lesson_plans, :pdf_file, :string
+    add_column :lesson_plans, :pdf_file_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323225102) do
+ActiveRecord::Schema.define(version: 20180328223103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,6 +194,8 @@ ActiveRecord::Schema.define(version: 20180323225102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "key"
+    t.string "pdf_file"
+    t.datetime "pdf_file_updated_at"
   end
 
   create_table "lessons", force: :cascade do |t|

--- a/lib/pdf_template.rb
+++ b/lib/pdf_template.rb
@@ -1,0 +1,41 @@
+class PdfTemplate
+  attr_reader :controller_options, :wicked_options
+
+  def initialize(options)
+    @controller_options = {
+      template: options.fetch(:template),
+      layout: "layouts/pdf.html.erb"
+    }
+
+    @wicked_options = options.slice!(:template)
+    wicked_options[:pdf] = wicked_options.delete(:name)
+    wicked_options.reverse_merge!(
+      margin: {
+        top: "0.6in",
+        bottom: "1in",
+        left: "1in",
+        right: "0.6in"
+      }
+    )
+  end
+
+  def render(locals)
+    controller = ApplicationController.new
+
+    locals.each do |name, value|
+      controller.instance_variable_set("@#{name}", value)
+    end
+
+    doc = controller.render_to_string(controller_options)
+
+    pdf = WickedPdf.new.pdf_from_string(doc, wicked_options)
+
+    tmp = Tempfile.new(["pdf", ".pdf"])
+    tmp.binmode
+    tmp.write(pdf)
+    tmp.flush
+    tmp.rewind
+
+    tmp
+  end
+end


### PR DESCRIPTION
This creates a very basic pdf format for lesson plans. The individual lessons are assembled together and a short table of contents is placed at the beginning. 