### PR TITLE
Fix xhr/js error when switching to intro tab

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -25,13 +25,15 @@ module ContentHelper
 
   def html(html, new_tab_for_all_links: true, glossary: nil)
     if html
-      cache_if(glossary, glossary && cache_key_for_html(html)) do
-        doc = Nokogiri::HTML.fragment(html)
-        process_links(doc, new_tab_for_all_links)
-        link_glossary(doc, glossary) if glossary
+      capture do
+        cache_if(glossary, glossary && cache_key_for_html(html)) do
+          doc = Nokogiri::HTML.fragment(html)
+          process_links(doc, new_tab_for_all_links)
+          link_glossary(doc, glossary) if glossary
 
-        r = doc.to_html.html_safe # rubocop:disable Rails/OutputSafety
-        concat(r)
+          r = doc.to_html.html_safe # rubocop:disable Rails/OutputSafety
+          concat(r)
+        end
       end
     end
   end


### PR DESCRIPTION
`cache_if` appends content directly to the output buffer, This is causing an error when switching to the intro tab from another lesson, since the content skips the `j` helper and doesn't get escaped:

https://github.com/EFForg/sec/blob/d791e7f42298fb3dc6eccaf665e627354a710473/app/views/topics/show.js.erb#L2
