### PR TITLE
Link to the full glossary from each glossary page

### DIFF
--- a/app/views/glossary/show.html.erb
+++ b/app/views/glossary/show.html.erb
@@ -1,5 +1,8 @@
 <div class="row">
   <div class="large-8 large-centered columns">
+    <div class="breadcrumb">
+      <%= link_to "< Browse the full glossary", glossary_index_path %>
+    </div>
     <h1><%= @term.name %></h1>
 
     <div class="content">


### PR DESCRIPTION
Closes https://github.com/EFForg/sec/issues/421

Looks like the links that take you from one lesson to the full lessons list:
![screen shot 2018-04-04 at 1 10 17 pm](https://user-images.githubusercontent.com/1065956/38331951-8ab11538-3809-11e8-8aa4-a79921062255.png)
