### PR TITLE
Fix failing tests

### DIFF
--- a/app/assets/javascripts/application/glossary.js
+++ b/app/assets/javascripts/application/glossary.js
@@ -1,18 +1,18 @@
-$(document).on('mouseover', '.glossary-term, .glossary-definition', (e) => {
+$(document).on('mouseover', '.glossary-term, .glossary-definition', function(e) {
   var def = $(e.target).closest('.glossary-term').find('.glossary-definition');
   clearTimeout(def.data('timeout'));
   def.data('timeout', null).show();
 });
 
-$(document).on('mouseout', '.glossary-term, .glossary-definition', (e) => {
+$(document).on('mouseout', '.glossary-term, .glossary-definition', function(e) {
   var def = $(e.target).closest('.glossary-term').find('.glossary-definition');
   if (!def.data('timeout')) {
-    def.data('timeout', setTimeout(() => {
+    def.data('timeout', setTimeout(function() {
       def.data('timeout', null).hide();
     }, 200));
   }
 });
 
-$(document).on('click', '.glossary-term', (e) => {
+$(document).on('click', '.glossary-term', function(e) {
   window.open($(e.target).find('a').attr('href'));
 });


### PR DESCRIPTION
Feature specs are broken on master because the JS engine behind capybara-webkit can't parse ES6 arrow syntax.