### PR TITLE
Fix float issues around topic header

### DIFF
--- a/app/assets/stylesheets/application/lessons.scss
+++ b/app/assets/stylesheets/application/lessons.scss
@@ -42,10 +42,6 @@
     clear: left;
     text-transform: uppercase;
     margin-bottom: 1rem;
-
-    @include breakpoint(large) {
-      float: left;
-    }
   }
   .topics-cards {
     padding-left: 0;
@@ -59,9 +55,6 @@
   }
 
   .tags {
-    float: left;
-    margin: 1rem 1rem 0 0;
-    width: auto;
     @include breakpoint(medium) {
       width: 60%;
     }


### PR DESCRIPTION
Fixes an issue where, on topics that have tags (currently just Threat Modelling), the tag improperly floats around the last modified header.