### PR TITLE
Wrap long links and style tables a bit

### DIFF
--- a/app/assets/stylesheets/application/content.scss
+++ b/app/assets/stylesheets/application/content.scss
@@ -1,0 +1,5 @@
+.content {
+  a {
+    word-break: break-word;
+  }
+}

--- a/app/assets/stylesheets/application/content.scss
+++ b/app/assets/stylesheets/application/content.scss
@@ -2,4 +2,11 @@
   a {
     word-break: break-word;
   }
+
+  table {
+    td:not(:last-child),
+    th:not(:last-child) {
+      padding-right: 1rem;
+    }
+  }
 }

--- a/app/assets/stylesheets/application/lessons.scss
+++ b/app/assets/stylesheets/application/lessons.scss
@@ -144,10 +144,6 @@
     padding: 1rem 0.5rem 2rem;
     z-index: 0;
 
-    a {
-      word-break: break-word;
-    }
-
     h3 {
       font-size: 1.1rem;
       line-height: 1.1rem;


### PR DESCRIPTION
Helps with the problems mentioned in #425. The pull-quote on https://sec.eff.org/articles/minimum-viable-teaching is actually a red herring, it's the long links at the bottom of the article that are overflowing the container. This branch adds `word-break: break-word` so that they get wrapped. It also adds a little styling for tables, though doesn't fix the issue with the chart on https://sec.eff.org/articles/learning-objectives being too big for mobile. I recommended they make a content change so that it fits better.

