### PR TITLE
Fix blank tabs opened by glossary terms

### DIFF
--- a/app/assets/javascripts/application/glossary.js
+++ b/app/assets/javascripts/application/glossary.js
@@ -14,5 +14,8 @@ $(document).on('mouseout', '.glossary-term, .glossary-definition', function(e) {
 });
 
 $(document).on('click', '.glossary-term', function(e) {
-  window.open($(e.target).find('a').attr('href'));
+  if (!$(e.target).closest('.glossary-definition').length) {
+    var url = $(e.target).closest('.glossary-term').find('a').attr('href');
+    window.open(url);
+  }
 });


### PR DESCRIPTION
When clicked in certain places (the `(i)` icon, the "Read more" link), glossary term links open a blank tab with no content.