### PR TITLE
Simplify relationships between Lesson, LessonPlan, Topic and Material

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -42,4 +42,13 @@ class Lesson < ApplicationRecord
   def decide_published
     self.published = body.try(:strip).present?
   end
+
+  def materials
+    url_helper = Rails.application.routes.url_helpers
+
+    Material.select do |material|
+      path = url_helper.material_path(material)
+      suggested_materials[path]
+    end
+  end
 end

--- a/spec/controllers/lessons_controller_spec.rb
+++ b/spec/controllers/lessons_controller_spec.rb
@@ -1,20 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe LessonsController, type: :controller do
-  let(:topic){ FactoryGirl.create(:topic) }
+  let(:lesson){ FactoryGirl.create(:lesson) }
 
   describe "GET #show" do
     it "returns http success" do
-      get :show, params: { topic_id: topic.slug,
-                           id: topic.lessons.first.level }
+      get :show, params: { topic_id: lesson.topic.slug, id: lesson.level }
       expect(response).to have_http_status(:success)
     end
 
     it "should protect unpublished content" do
-      topic.unpublish
+      lesson.topic.unpublish
       expect {
-        get :show, params: { topic_id: topic.slug,
-                             id: topic.lessons.first.level }
+        get :show, params: { topic_id: lesson.topic.slug, id: lesson.level }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/controllers/materials_controller_spec.rb
+++ b/spec/controllers/materials_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MaterialsController, type: :controller do
-  let(:topic){ FactoryGirl.create(:topic) }
+  let(:lesson){ FactoryGirl.create(:lesson) }
   let(:material){ FactoryGirl.create(:material) }
 
   describe "GET #index" do
@@ -14,7 +14,7 @@ RSpec.describe MaterialsController, type: :controller do
 
   describe "GET #show" do
     it "returns http success" do
-      topic.lessons.take.update(
+      lesson.update(
         suggested_materials: "/materials/#{material.to_param}"
       )
 

--- a/spec/factories/lesson_plans.rb
+++ b/spec/factories/lesson_plans.rb
@@ -4,8 +4,8 @@ FactoryGirl.define do
 
     factory :lesson_plan_with_lesson do
       after(:create) do |plan|
-        topic = FactoryGirl.create(:topic)
-        plan.lessons << topic.lessons.first
+        lesson = FactoryGirl.create(:lesson)
+        plan.lessons << lesson
       end
     end
 

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :lesson do
+    body "lesson body"
+    topic { |a| a.association :topic }
+  end
+end

--- a/spec/factories/topic.rb
+++ b/spec/factories/topic.rb
@@ -1,16 +1,6 @@
 FactoryGirl.define do
   factory :topic do
     name "A topic"
-
-    after(:create) do |topic|
-      FactoryGirl.create(:lesson, topic_id: topic.id)
-      topic.lessons.reload
-    end
-
     published true
-  end
-
-  factory :lesson do
-    body "lesson body"
   end
 end

--- a/spec/features/add_to_lesson_plans_spec.rb
+++ b/spec/features/add_to_lesson_plans_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "AddToLessonPlans", type: :feature, js: true do
   let(:topic){ FactoryGirl.create(:topic) }
-  let(:lesson){ topic.lessons.first }
+  let!(:lesson){ FactoryGirl.create(:lesson, topic: topic) }
   let(:lesson_plan) { FactoryGirl.create(:lesson_plan) }
 
   context "lesson plan doesn't exist yet" do
@@ -22,14 +22,13 @@ RSpec.feature "AddToLessonPlans", type: :feature, js: true do
 
   context "lesson plan exists" do
     before{ page.set_rack_session(lesson_plan_id: lesson_plan.id) }
-    scenario "user adds a lesson to an existing lesson plan" do
-      lesson_plan.lessons << FactoryGirl.create(:topic).lessons.first
 
+    scenario "user adds a lesson to an existing lesson plan" do
       visit topic_path(topic)
       click_button "Add To Lesson Plan"
       find_button("Remove From Lesson Plan")
 
-      expect(lesson_plan.lessons.count).to eq(2)
+      expect(lesson_plan.lessons.count).to eq(1)
     end
 
     scenario "user removes a lesson from a lesson plan" do

--- a/spec/jobs/update_lesson_pdf_spec.rb
+++ b/spec/jobs/update_lesson_pdf_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe UpdateLessonPdf do
-  let(:lesson){ FactoryGirl.create(:topic).lessons.take }
+  let(:lesson){ FactoryGirl.create(:lesson) }
 
   describe "#perform" do
     it "should create a PDF" do

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Lesson do
+  def wysiwyg_for_materials(materials)
+    materials.map do |m|
+      url = Rails.application.routes.url_helpers.material_path(m)
+      "<p>#{m.name}</p><a href='#{url}'>link</a>"
+    end.join
+  end
+
+  describe "#materials" do
+    it "returns an empty array" do
+      expect(FactoryGirl.create(:lesson).materials).to be_empty
+    end
+
+    context "with materials" do
+      let!(:material) { FactoryGirl.create(:material, name: "A rad handout") }
+      let!(:material2) { FactoryGirl.create(:material, name: "A Great GIF") }
+      let!(:not_my_material) { FactoryGirl.create(:material) }
+      let(:lesson) do
+        FactoryGirl.create(
+          :lesson, suggested_materials: wysiwyg_for_materials([material, material2])
+        )
+      end
+
+      it "returns linked materials" do
+        expect(lesson.materials).to match_array([material, material2])
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Decouple Topic and Lesson factories 
* Associate Lessons and Materials 

Work I did in service of [bundling materials into the lesson_plan zip](https://github.com/EFForg/sec/issues/431), before I gave up on that.  Maybe this is still useful refactory.