### PR TITLE
Changes to Feedback page as requested by Soraya

### DIFF
--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -2,11 +2,16 @@
   <h1>SEC Website Satisfaction Survey</h1>
 
   <p>
-    Please tell us what you think about SEC. Your thoughts will help us help you make your teaching experience impactful. Thank you!
+    Thank you for giving feedback on the Security Education Companion (SEC)!
   </p>
 
   <p>
-    Or, contact us by email at <%= link_to "sec-feedback@eff.org", "mailto:sec-feedback@eff.org" %>.
+    When possible, please give concrete, specific feedback and examples to our questions below, as this will help us to improve on and add to the site.
+  </p>
+
+  <p>
+    We will hold the information submitted in accordance with
+    <a href="https://eff.org/policy">EFF’s privacy policy.</a>
   </p>
 
   <h2>Survey questions</h2>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -25,6 +25,7 @@
     </ul>
 
     <ul class="about">
+      <li><%= link_to "Submit Feedback", feedback_root_path %></li>
       <li><%= link_to "Contact", "mailto:sec-feedback@eff.org" %></li>
       <li><%= link_to "Credits", "/credits" %></li>
       <li><%= link_to "Privacy", "https://www.eff.org/policy" %></li>

--- a/spec/features/give_feedback_spec.rb
+++ b/spec/features/give_feedback_spec.rb
@@ -79,4 +79,11 @@ RSpec.feature "GiveFeedback", type: :feature, js: true do
 
     expect(feedback.source_url).to eq(source_url)
   end
+
+  scenario "user submits site-wide feedback" do
+    Homepage.create(welcome: "", articles_intro: "")
+    visit root_path
+    find("footer a", text: /Submit Feedback/i).click
+    expect(page).to have_content("SEC Website Satisfaction Survey")
+  end
 end


### PR DESCRIPTION

* Change the copy at the top of the Feedback page
* Link to the feedback page in the footer

<img width="877" alt="screen shot 2018-04-16 at 1 02 21 pm" src="https://user-images.githubusercontent.com/1065956/38834483-7487ee1c-417d-11e8-8ecf-873df2df9a2c.png">
<img width="1200" alt="screen shot 2018-04-16 at 1 02 45 pm" src="https://user-images.githubusercontent.com/1065956/38834484-74aa3f94-417d-11e8-84ed-5807627a3764.png">