### PR TITLE
Fix lesson_plan_lessons counter cache

### DIFF
--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -6,11 +6,8 @@ class LessonPlan < ApplicationRecord
     counter_cache: "lessons_count",
     after_remove: ->(plan, _){ plan.update_column(:pdf_file_updated_at, nil) }
 
-  has_many :lessons, through: :lesson_plan_lessons do
-    def ordered
-      merge(LessonPlanLesson.ordered)
-    end
-  end
+  has_many :lessons, ->{ reorder!.merge(LessonPlanLesson.ordered) },
+    through: :lesson_plan_lessons
 
   accepts_nested_attributes_for :lesson_plan_lessons,
                                 allow_destroy: true

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -2,10 +2,15 @@ require_dependency "duration"
 require_dependency "pdf_template"
 
 class LessonPlan < ApplicationRecord
-  has_many :lesson_plan_lessons, -> { order(:position) },
+  has_many :lesson_plan_lessons,
+    counter_cache: "lessons_count",
     after_remove: ->(plan, _){ plan.update_column(:pdf_file_updated_at, nil) }
 
-  has_many :lessons, through: :lesson_plan_lessons
+  has_many :lessons, through: :lesson_plan_lessons do
+    def ordered
+      merge(LessonPlanLesson.ordered)
+    end
+  end
 
   accepts_nested_attributes_for :lesson_plan_lessons,
                                 allow_destroy: true

--- a/app/models/lesson_plan_lesson.rb
+++ b/app/models/lesson_plan_lesson.rb
@@ -3,10 +3,13 @@ class LessonPlanLesson < ApplicationRecord
   belongs_to :lesson
 
   scope :published, ->{
+    ordered.
     joins(lesson: :topic).
       merge(Topic.published).
       merge(Lesson.published)
   }
+
+  scope :ordered, ->{ order(:position) }
 
   validate :lesson_must_be_published
 

--- a/app/views/lesson_plans/show.pdf.erb
+++ b/app/views/lesson_plans/show.pdf.erb
@@ -2,7 +2,7 @@
   <h1>Lesson Plan:</h1>
 
   <ol>
-    <% @lesson_plan.lessons.ordered.each do |lesson| %>
+    <% @lesson_plan.lessons.published.each do |lesson| %>
       <li><em><strong><%= lesson.name %></strong> <%= "(#{lesson.duration.in_words})" unless lesson.duration.length.zero? %></em></li>
     <% end %>
   </ol>
@@ -29,7 +29,7 @@
   <% end %>
 </div>
 
-<% @lesson_plan.lessons.ordered.each do |lesson| %>
+<% @lesson_plan.lessons.published.each do |lesson| %>
   <%= page_break %>
   <% @topic, @lesson = lesson.topic, lesson %>
   <%= render template: "lessons/show" %>

--- a/app/views/lesson_plans/show.pdf.erb
+++ b/app/views/lesson_plans/show.pdf.erb
@@ -2,7 +2,7 @@
   <h1>Lesson Plan:</h1>
 
   <ol>
-    <% @lesson_plan.lessons.each do |lesson| %>
+    <% @lesson_plan.lessons.ordered.each do |lesson| %>
       <li><em><strong><%= lesson.name %></strong> <%= "(#{lesson.duration.in_words})" unless lesson.duration.length.zero? %></em></li>
     <% end %>
   </ol>
@@ -29,7 +29,7 @@
   <% end %>
 </div>
 
-<% @lesson_plan.lessons.each do |lesson| %>
+<% @lesson_plan.lessons.ordered.each do |lesson| %>
   <%= page_break %>
   <% @topic, @lesson = lesson.topic, lesson %>
   <%= render template: "lessons/show" %>


### PR DESCRIPTION
Fixes #457. The problem was a combination of the fact that we have a custom column name for the counter cache, and that counter caches don't work on associations that include a scope.