### PR TITLE
Support running chrome in its own container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ POSTGRES_PASSWORD=mysecretpassword
 
 REDIS_URI=redis://redis/0/cache
 
+# Set if you're using the chrome container
+# CHROME_HOST=chrome
+# CHROME_PORT=9222
+
 SENTRY_DSN=
 SENTRY_PUBLIC_DSN=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >>/etc/apk/repositor
     nodejs \
     yarn \
 
-    chromium@edgecommunity \
-
-    # Needed by html-pdf-chrome dependency
-    grep@edge \
-
   # Set up crontab.
   && echo "*/15 * * * * su -s/bin/sh www-data -c \
     'cd /opt/trainers-hub && bundle exec rake blog:update' >>/proc/1/fd/1 2>&1" >>/etc/crontabs/root \

--- a/bin/html-pdf-chrome
+++ b/bin/html-pdf-chrome
@@ -2,9 +2,10 @@
 
 var process = require('process');
 var fs = require('fs');
+var dns = require('dns');
 
 var argv = require('minimist')(process.argv.slice(2), {
-  string: ['html', 'pdf']
+  string: ['html', 'pdf', 'chrome-host', 'chrome-port']
 });
 
 var htmlPdf = require('../node_modules/html-pdf-chrome');
@@ -26,6 +27,29 @@ var options = {
   ]
 };
 
-htmlPdf.create(html, options).then(function(pdf) {
-  pdf.toFile(argv['pdf']);
-});
+if (argv['chrome-port']) {
+  options.port = argv['chrome-port'];
+}
+
+if (argv['chrome-host']) {
+  dns.lookup(argv['chrome-host'], function(err, ip) {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    options.host = ip;
+    run();
+  });
+} else {
+  run();
+}
+
+function run() {
+  htmlPdf.create(html, options).then(function(pdf) {
+    pdf.toFile(argv['pdf']);
+  }).catch(function(e) {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -76,3 +76,10 @@ services:
 #     env_file: .env
 #
 #     command: bundle exec rake jobs:work
+
+# Chrome browser for production
+#   chrome:
+#     image: justinribeiro/chrome-headless:latest
+#     command: --headless --disable-gpu --no-sandbox \
+#              --remote-debugging-address=0.0.0.0 \
+#              --remote-debugging-port=9222

--- a/lib/pdf_template.rb
+++ b/lib/pdf_template.rb
@@ -1,6 +1,8 @@
 require "shellwords"
 
 class PdfTemplate
+  Error = Class.new(Exception)
+
   attr_reader :controller_options
 
   def initialize(options)
@@ -37,6 +39,14 @@ class PdfTemplate
                "--html=#{input}",
                "--pdf=#{output.path}"]
 
+    if ENV["CHROME_HOST"]
+      command << "--chrome-host=#{ENV["CHROME_HOST"]}"
+    end
+
+    if ENV["CHROME_PORT"]
+      command << "--chrome-port=#{ENV["CHROME_PORT"]}"
+    end
+
     Rails.logger.info(Shellwords.shelljoin(command))
 
     begin
@@ -46,6 +56,8 @@ class PdfTemplate
       Process.kill("TERM", pid)
       raise e
     end
+
+    raise Error, "html-pdf-chrome command failed" unless $?.success?
 
     output
   end


### PR DESCRIPTION
The new library we're using to print from chrome made this really easy. It should still work as before when run outside of docker (launching `chromium-browser` on demand), or you can keep a chrome process running and set CHROME_HOST=localhost.