### PR TITLE
Lesson plan PDF/zip format fixes

### DIFF
--- a/app/controllers/concerns/zipping.rb
+++ b/app/controllers/concerns/zipping.rb
@@ -6,7 +6,7 @@ module Zipping
       path = URI::escape(file.path[Rails.root.join("public").to_s.size..-1])
       path = "/#{path}" unless path.starts_with?("/")
 
-      filename = File.basename(path)
+      filename = File.basename(file.path)
       filename = sprintf("%0#{digits}d-%s", i+1, filename) if number
 
       "- #{file.size} #{path} #{filename}"

--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -3,15 +3,28 @@ module PdfHelper
     content_tag(:div, "", class: "page-break")
   end
 
-  def asset_data_uri(path)
-    asset = Rails.application.assets.find_asset(path)
-    data = Base64.encode64(asset.source)
-    "data:#{asset.content_type};base64,#{Rack::Utils.escape(data)}"
+  def asset_data_uri(asset)
+    asset_data = get_asset(asset)
+    data = Base64.encode64(asset_data.source)
+    "data:#{asset_data.content_type};base64,#{Rack::Utils.escape(data)}"
   end
 
   def pdf_style_sheet
+    asset_data = get_asset("pdf.css")
     content_tag(:style, type: "text/css") do
-      Rails.application.assets.find_asset("pdf.scss").to_s.html_safe # rubocop:disable Rails/OutputSafety
+      asset_data.source.html_safe # rubocop:disable Rails/OutputSafety
+    end
+  end
+
+  def get_asset(asset)
+    if Rails.application.config.assets.compile
+      Rails.application.assets.find_asset(asset)
+    else
+      path = compute_asset_path(asset).remove(%r{^/})
+      OpenStruct.new(
+        source: File.read(Rails.root.join("public", path)),
+        content_type: Rack::Mime.mime_type(File.extname(path))
+      )
     end
   end
 end

--- a/lib/zip_middleware.rb
+++ b/lib/zip_middleware.rb
@@ -33,7 +33,6 @@ class ZipMiddleware
         _, size, path, filename = item.strip.split(" ", 4)
 
         path = URI::unescape(path).remove(%r{^/+})
-        filename = URI::unescape(filename)
 
         link = Pathname.new(dir).join(filename)
 

--- a/spec/controllers/concerns/zipping_spec.rb
+++ b/spec/controllers/concerns/zipping_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Zipping do
+  controller_class = Class.new(ApplicationController) do
+    include Zipping
+  end
+
+  let(:controller) do
+    controller_class.new.tap do |c|
+      c.response = ActionDispatch::Response.new
+    end
+  end
+
+  let(:files) do
+    5.times.map do |i|
+      double(
+        size: rand(10000),
+        path: Rails.root.join("public", "files/file #{i}.pdf").to_s
+      )
+    end
+  end
+
+  describe "#send_archive(files)" do
+    it "should set the X-Archive-Files header" do
+      expect(controller.response.headers)
+        .to receive(:[]=).with("X-Archive-Files", "zip").once
+
+      allow(controller.response.headers)
+        .to receive(:[]=).and_call_original
+
+      controller.send_archive(files)
+    end
+
+    it "should send a response formatted for nginx's zip module" do
+      expect(controller).to receive(:send_data) do |*args|
+        manifest, opts = args
+
+        ref = files.map do |f|
+          path = URI::escape(f.path[Rails.root.join("public").to_s.size..-1])
+          name = File.basename(f.path)
+          "- #{f.size} #{path} #{name}"
+        end.join("\r\n")
+
+        expect(manifest).to eq(ref)
+      end
+
+      controller.send_archive(files, number: false)
+    end
+  end
+end

--- a/spec/controllers/lesson_plans_controller_spec.rb
+++ b/spec/controllers/lesson_plans_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe LessonPlansController, type: :controller do
+  let(:lesson_plan){ FactoryGirl.create(:lesson_plan_with_lesson) }
+  let(:files){ double(all?: true) }
+
+  describe ".zip format" do
+    it "should send back send_archive(lesson_plan.files)" do
+      expect_any_instance_of(LessonPlan).to receive(:files){ files }
+      expect(controller).to receive(:send_archive).with(files) do
+        controller.head :ok
+      end
+
+      get :show, params: { id: lesson_plan.key, format: :zip }
+    end
+  end
+end


### PR DESCRIPTION
To inline assets into the PDF template we are using `Rails.application.assets`, but this value isn't loaded in production where we have `config.assets.compile = false`. This branch fixes the issue by looking for the precompiled file under public/assets.

It also fixes #478 by not URI escaping filenames in the nginx zip manifest.