### PR TITLE
Add url to lesson plan pdf

### DIFF
--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -197,7 +197,7 @@ h1 {
 
 @page {
   size: auto;
-  margin: 0.6in 1in 1.5in 1in;
+  margin: 0.6in 1in 0.8in 1in;
 }
 
 #header {

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -28,7 +28,8 @@ class LessonPlan < ApplicationRecord
   def recreate_pdf_file
     pdf = PdfTemplate.new(
       name: "Lesson Plan",
-      template: "lesson_plans/show.pdf.erb"
+      template: "lesson_plans/show.pdf.erb",
+      source: { controller: "lesson_plans", action: "show", id: key }
     )
 
     locals = {

--- a/bin/html-pdf-chrome
+++ b/bin/html-pdf-chrome
@@ -5,7 +5,7 @@ var fs = require('fs');
 var dns = require('dns');
 
 var argv = require('minimist')(process.argv.slice(2), {
-  string: ['html', 'pdf', 'chrome-host', 'chrome-port']
+  string: ['html', 'pdf', 'chrome-host', 'chrome-port', 'footer']
 });
 
 var htmlPdf = require('../node_modules/html-pdf-chrome');
@@ -24,8 +24,17 @@ var options = {
     '--no-sandbox',
     '--headless',
     '--hide-scrollbars',
-  ]
+  ],
+  printOptions: {
+    displayHeaderFooter: true,
+    headerTemplate: '<div class="text"></div>',
+    footerTemplate: footerContent('')
+  }
 };
+
+if (argv['footer']) {
+  options.printOptions.footerTemplate = footerContent(argv['footer']);
+}
 
 if (argv['chrome-port']) {
   options.port = argv['chrome-port'];
@@ -52,4 +61,15 @@ function run() {
     console.error(e);
     process.exit(1);
   });
+}
+
+function footerContent(content) {
+  return [
+    '<div class="text center">',
+    content,
+    '<div style="float: right">',
+    '<span class="pageNumber"></span>/<span class="totalPages"></span>',
+    '</div>',
+    '</div>'
+  ].join('');
 }

--- a/spec/lib/pdf_template_spec.rb
+++ b/spec/lib/pdf_template_spec.rb
@@ -7,18 +7,16 @@ RSpec.describe PdfTemplate do
 
   describe "#render" do
     let(:topic){ Topic.new }
-    let!(:controller){ ApplicationController.new }
 
     it "should render the template with the given instance variables" do
       doc = "<h1>It works!</h1>"
 
-      expect(ApplicationController).to receive(:new){ controller }
-      expect(controller).to receive(:instance_variable_set).
-                             with("@topic", topic)
-      expect(controller).to receive(:render_to_string).
-                             with(layout: "layouts/pdf.html.erb",
-                                  template: template).
-                             and_return(doc)
+      expect(ApplicationController).to receive(:render) do |opts|
+        expect(opts[:assigns]).to eq(topic: topic)
+        expect(opts[:template]).to eq(template)
+        expect(opts[:layout]).to eq("layouts/pdf.html.erb")
+      end.and_return(doc)
+
       expect(pdf_template).to receive(:rebase_urls).and_return(doc)
       expect(pdf_template).to receive(:print_pdf)
 


### PR DESCRIPTION
Fixes #488. I put the URL in the footer of each page rather than at the top of the lesson plan, after playing around with the placement a bit I found that worked better. This branch includes some other improvements to the PDF format, like adding page numbers, and using nice [rails 5 features](https://evilmartians.com/chronicles/new-feature-in-rails-5-render-views-outside-of-actions) to render the template instead of messing around with `instance_variable_set`/`render_to_string`.