### PR TITLE
Set default_url_options from server environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,12 @@ module TrainersHub
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    config.action_controller.default_url_options = {
+      host: ENV["SERVER_HOST"],
+      port: ENV["SERVER_PORT"],
+      protocol: ENV["SERVER_PROTOCOL"]
+    }
+
     if ENV["NO_NGINX"]
       require_dependency "zip_middleware"
       config.middleware.use ZipMiddleware

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,5 +40,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  config.action_controller.default_url_options = {
+    host: "sec.example.com"
+  }
+
   config.middleware.use RackSessionAccess::Middleware
 end


### PR DESCRIPTION
Whoops, this should have been in #489. We need to set `config.action_controller.default_url_options` so that url helpers work outside of a request context (ie when creating PDFs).