### PR TITLE
Switch from imagemagick to graphicsmagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >>/etc/apk/repositor
     build-base \
     postgresql-dev \
     postgresql-client \
-    imagemagick \
+    graphicsmagick \
     ghostscript \
     nodejs \
     yarn \


### PR DESCRIPTION
ImageMagick is failing hard (abort w/ core dump) when processing new PDFs from Soraya. I tried upgrading to a later version, but that also failed. This branch switches our image processing over to graphicsmagick (an imagemagick fork which is supposedly more stable), which has fixed processing of the PDF attached in  https://redmine.eff.org/issues/19923.
