### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,8 @@ addons:
   apt:
     packages:
       - wkhtmltopdf
-before_install:
-  - gem install bundler
-install:
-  - bundle install --path vendor/bundle
-  - npm install
 before_script:
+  - npm install
   - psql -c 'create database "trainers-hub_test";' -U postgres
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/Gemfile
+++ b/Gemfile
@@ -103,8 +103,8 @@ group :test do
   gem "rspec-core"
   gem "rspec-rails"
   # Run browser tests with selenium and headless chrome
-  gem "chromedriver-helper"
   gem "selenium-webdriver"
+  gem "webdrivers"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,4 +426,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
     babel-source (5.8.35)
@@ -88,9 +86,6 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     ckeditor (4.2.4)
       cocaine
       orm_adapter (~> 0.5.0)
@@ -164,7 +159,6 @@ GEM
       responders
     invisible_captcha (0.10.0)
       rails (>= 3.2.0)
-    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -204,6 +198,7 @@ GEM
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -367,6 +362,11 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -384,7 +384,6 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   carrierwave
-  chromedriver-helper
   ckeditor
   delayed_job_active_record
   devise
@@ -424,6 +423,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 BUNDLED WITH
    2.0.1


### PR DESCRIPTION
Upgraded Bundler to 2.0.1 to please Travis, you can upgrade your local bundler [like this](https://bundler.io/guides/bundler_2_upgrade.html) and it will fall back to Bundler 1 when necessary :)

Travis calls its own `bundler` by default on Ruby projects with a Gemfile present, so I let it use the default install script for that.

`chromedriver-helpers` is deprecated in favor of `webdrivers`.