### PR TITLE
Rebuild Nginx with mod_zip on top of nginx:alpine

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,21 +1,18 @@
-FROM debian:jessie-slim
+FROM nginx:alpine
 
-ENV NGINX_VERSION=1.15.8
-
-# install system packages
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      build-essential \
-      git \
-      libpcre3-dev \
-      zlib1g-dev \
-      curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && adduser --system --group --no-create-home --disabled-login --disabled-password nginx \
-
-    # install nginx
-    && curl -LO http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+# Rebuild nginx with mod_zip so we can serve zippped lesson plans.
+RUN apk add --no-cache --virtual .build-deps \
+		gcc \
+		libc-dev \
+		make \
+		pcre-dev \
+		zlib-dev \
+		linux-headers \
+		curl \
+		libxslt-dev \
+		gd-dev \
+    git \
+    && curl -LO https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
     && tar zxf nginx-${NGINX_VERSION}.tar.gz \
     && cd nginx-${NGINX_VERSION} \
     && git -c http.sslVerify=false clone https://github.com/evanmiller/mod_zip.git \
@@ -23,6 +20,7 @@ RUN apt-get update \
         --prefix=/usr \
         --user=nginx \
         --group=nginx \
+        --conf-path=/etc/nginx/nginx.conf \
         --http-log-path=/dev/stdout \
         --error-log-path=/dev/stdout \
         --with-pcre-jit \
@@ -38,11 +36,8 @@ RUN apt-get update \
     && cd .. \
     && rm -f nginx-${NGINX_VERSION}.tar.gz \
     && rm -rf nginx-${NGINX_VERSION} \
+    && apk del .build-deps \
+    && mkdir -p /etc/nginx/sites-enabled
 
-    && mkdir -p /var/www/html /etc/nginx/conf.d /etc/nginx/sites-enabled
-
-COPY init /
-COPY nginx.conf /etc/nginx/
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY sec.conf /etc/nginx/sites-enabled
-
-CMD [ "/init", "-c", "/etc/nginx/nginx.conf" ]

--- a/nginx/init
+++ b/nginx/init
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /usr/sbin/nginx "$@"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,24 +1,25 @@
+user nginx;
 worker_processes auto;
-pid /run/nginx.pid;
-daemon off;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
 
 events {
     worker_connections 2000;
 }
 
 http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log  /var/log/nginx/access.log;
+
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
     server_names_hash_bucket_size 64;
-
-    include /usr/conf/mime.types;
-    default_type application/octet-stream;
-
-    access_log /dev/stdout;
-    error_log  /dev/stdout;
 
     gzip on;
     gzip_disable "msie6";


### PR DESCRIPTION
This is for Redmine #19718

* Switches the OS to Apline
* Rebuilds Nginx on top of the mainline Nginx Alpine image. That lets us take advantage some of the [setup performed in the base image](https://github.com/nginxinc/docker-nginx/blob/97b65112180e0c7764465aa47a974fc7af3c99ae/mainline/alpine/Dockerfile) including setting `NGINX_VERSION`.

This is currently deployed on staging.

(CI won't pass until #549 lands)