### PR TITLE
Alt text for upload previews

### DIFF
--- a/app/assets/stylesheets/application/materials.scss
+++ b/app/assets/stylesheets/application/materials.scss
@@ -41,6 +41,7 @@
 
   .upload-description {
     font-weight: 400;
+    white-space: pre-wrap;
   }
   .material-img {
     padding: 1rem 1rem 1rem 0;

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -3,24 +3,20 @@ module UploadsHelper
     return if file.blank?
 
     if file.full_preview.url
-      preview = image_tag(file.full_preview.url)
+      image_tag(file.full_preview.url, alt: "")
     else
-      preview = fallback(file)
+      fallback(file)
     end
-
-    link_to preview, file.url, class: "file-preview"
   end
 
   def thumbnail(file)
     return if file.blank?
 
     if file.thumbnail.url
-      preview = image_tag(file.thumbnail.url)
+      image_tag(file.thumbnail.url, alt: "")
     else
-      preview = fallback(file)
+      fallback(file)
     end
-
-    link_to preview, file.model.material, class: "file-preview"
   end
 
   def fallback(file)

--- a/app/views/materials/_material.html.erb
+++ b/app/views/materials/_material.html.erb
@@ -1,10 +1,10 @@
 <%= render "content/teaser", content: material do %>
-  <div class="material-preview">
-    <%= thumbnail(material.first_file) %>
-  </div>
-
-  <h3>
-    <%= link_to material.name, material %>
-  </h3>
-
+  <%= link_to(material, class: "file-preview") do %>
+    <div class="material-preview">
+      <%= thumbnail(material.first_file) %>
+    </div>
+    <h3>
+      <%= material.name %>
+    </h3>
+  <% end %>
 <% end %>

--- a/app/views/materials/show.html.erb
+++ b/app/views/materials/show.html.erb
@@ -30,12 +30,14 @@
           <div class="upload-description"><%= upload.description %></div>
           <% end %>
 
-          <div class="material-img">
-            <%= full_preview(upload.file) %>
-          </div>
-          <div class="material-link">
-            <%= link_to file_name(upload.file), upload.file.url %>
-          </div>
+          <%= link_to(upload.file.url) do %>
+            <div class="material-img">
+              <%= full_preview(upload.file) %>
+            </div>
+            <div class="material-link">
+              Download <%= file_name(upload.file) %>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Based on my reading of https://webaim.org/techniques/alttext/....

The text displayed with the thumbnail and the full preview images describes them pretty well, so I don't think additional alt text is needed. However, according to example 3, "An image that is the only thing inside a link must never have a missing or null alt attribute.", so I wrapped the image and associated text in a single link tag. 

I noticed that the whitespace in the description field was getting lost (for example on https://sec.eff.org/materials/Transport-Layer-vs-End-to-End) so I added `pre-wrap` to preserve it.

Closes #366 