### PR TITLE
adding glossary to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -25,6 +25,7 @@
       <li><%= link_to "Lessons", topics_path %></li>
       <li><%= link_to "Security News", blog_path %></li>
       <li><%= link_to "Teaching Materials", materials_path %></li>
+      <li><%= link_to "Glossary", "/glossary" %></li>
     </ul>
 
     <ul class="about">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -25,7 +25,7 @@
       <li><%= link_to "Lessons", topics_path %></li>
       <li><%= link_to "Security News", blog_path %></li>
       <li><%= link_to "Teaching Materials", materials_path %></li>
-      <li><%= link_to "Glossary", "/glossary" %></li>
+      <li><%= link_to "Glossary", glossary_index_path %></li>
     </ul>
 
     <ul class="about">


### PR DESCRIPTION
I'm wondering if there's a more railsy way to do this. glossary_path requires an id parameter so I wasn't sure if I could modify that in some way to have the direct path.