### PR TITLE
Allow admins to export entire site to markdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >>/etc/apk/repositor
     ghostscript \
     nodejs \
     yarn \
+    zip \
 
   # Use Bundler 2.
   && gem install bundler -v "$BUNDLER_VERSION" --force \

--- a/app/admin/export.rb
+++ b/app/admin/export.rb
@@ -1,0 +1,15 @@
+ActiveAdmin.register_page "Export" do
+  controller { include Zipping }
+
+  page_action :zip, method: :post do
+    send_file(
+      MarkdownArchive.new.zip,
+      filename: "sec.eff.org-#{Time.now.strftime('%Y-%m-%d')}.zip"
+    )
+  end
+
+  action_item :add do
+    link_to "Markdown/zip archive",
+            admin_export_zip_path, method: :post
+  end
+end

--- a/app/models/markdown_archive.rb
+++ b/app/models/markdown_archive.rb
@@ -1,0 +1,66 @@
+class MarkdownArchive
+  attr_accessor :articles, :topics
+
+  def initialize(articles: Article.all, topics: Topic.all)
+    self.articles = articles
+    self.topics = topics
+  end
+
+  def zip
+    Dir.mktmpdir do |tmp|
+      tmp = Pathname.new(tmp)
+
+      articles.each do |article|
+        add_article(tmp, article)
+      end
+
+      topics.each do |topic|
+        topic.lessons.each do |lesson|
+          add_lesson(tmp, lesson)
+        end
+      end
+
+      zip = Tempfile.new(['archive', '.zip'])
+      File.delete(zip.to_path)
+
+      system(
+        'sh', '-c',
+        "cd #{tmp.to_s} && zip -r a.zip . && mv a.zip #{zip.to_path}"
+      )
+
+      return zip.to_path
+    end
+  end
+
+  private
+
+  def add_article(tmp, article)
+    doc = ArticlesController.render(
+      template: "articles/show.md.erb",
+      assigns: { article: article }
+    )
+
+    path = [
+      "Articles",
+      article.name.strip.gsub("/", "-") + ".md"
+    ].join("/")
+
+    FileUtils.mkdir_p(File.dirname(tmp.join(path)))
+    File.open(tmp.join(path), 'w'){ |f| f.write(doc) }
+  end
+
+  def add_lesson(tmp, lesson)
+    doc = TopicsController.render(
+      template: "lessons/show.md.erb",
+      assigns: { topic: lesson.topic, lesson: lesson }
+    )
+
+    path = [
+      "Lessons",
+      lesson.topic.name.strip.gsub("/", "-") + " - #{lesson.level}.md"
+    ].join("/")
+
+    FileUtils.mkdir_p(File.dirname(tmp.join(path)))
+    File.open(tmp.join(path), 'w'){ |f| f.write(doc) }
+  end
+end

--- a/app/models/markdown_archive.rb
+++ b/app/models/markdown_archive.rb
@@ -20,12 +20,12 @@ class MarkdownArchive
         end
       end
 
-      zip = Tempfile.new(['archive', '.zip'])
+      zip = Tempfile.new(["archive", ".zip"])
       File.delete(zip.to_path)
 
       system(
-        'sh', '-c',
-        "cd #{tmp.to_s} && zip -r a.zip . && mv a.zip #{zip.to_path}"
+        "sh", "-c",
+        "cd #{tmp} && zip -r a.zip . && mv a.zip #{zip.to_path}"
       )
 
       return zip.to_path
@@ -46,7 +46,7 @@ class MarkdownArchive
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))
-    File.open(tmp.join(path), 'w'){ |f| f.write(doc) }
+    File.open(tmp.join(path), "w"){ |f| f.write(doc) }
   end
 
   def add_lesson(tmp, lesson)
@@ -61,6 +61,6 @@ class MarkdownArchive
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))
-    File.open(tmp.join(path), 'w'){ |f| f.write(doc) }
+    File.open(tmp.join(path), "w"){ |f| f.write(doc) }
   end
 end


### PR DESCRIPTION
Adds a page in the admin area with a single action: export every published article/lesson to markdown, and send the collection back as a zip archive.
