### PR TITLE
markdown-zip

### DIFF
--- a/app/models/markdown_archive.rb
+++ b/app/models/markdown_archive.rb
@@ -72,8 +72,8 @@ class MarkdownArchive
     )
 
     path = [
-      "Lessons",
-      lesson.topic.name.strip.gsub("/", "-") + " - #{lesson.level}.md"
+      "Topics",
+      lesson.topic.name.strip.gsub("/", "-") + " - #{lesson.level.capitalize}.md"
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))

--- a/app/models/markdown_archive.rb
+++ b/app/models/markdown_archive.rb
@@ -15,6 +15,7 @@ class MarkdownArchive
       end
 
       topics.each do |topic|
+        add_topic(tmp, topic)
         topic.lessons.each do |lesson|
           add_lesson(tmp, lesson)
         end
@@ -43,6 +44,21 @@ class MarkdownArchive
     path = [
       "Articles",
       article.name.strip.gsub("/", "-") + ".md"
+    ].join("/")
+
+    FileUtils.mkdir_p(File.dirname(tmp.join(path)))
+    File.open(tmp.join(path), "w"){ |f| f.write(doc) }
+  end
+
+  def add_topic(tmp, topic)
+    doc = TopicsController.render(
+      template: "topics/show.md.erb",
+      assigns: { topic: topic }
+    )
+
+    path = [
+      "Topics",
+      topic.name.strip.gsub("/", "-") + " - Intro.md"
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))

--- a/app/models/markdown_archive.rb
+++ b/app/models/markdown_archive.rb
@@ -58,7 +58,7 @@ class MarkdownArchive
 
     path = [
       "Topics",
-      topic.name.strip.gsub("/", "-") + " - Intro.md"
+      topic.name.strip.gsub("/", "-") + "/Intro.md"
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))
@@ -73,7 +73,7 @@ class MarkdownArchive
 
     path = [
       "Topics",
-      lesson.topic.name.strip.gsub("/", "-") + " - #{lesson.level.capitalize}.md"
+      lesson.topic.name.strip.gsub("/", "-") + "/#{lesson.level.capitalize}.md"
     ].join("/")
 
     FileUtils.mkdir_p(File.dirname(tmp.join(path)))

--- a/app/views/topics/show.md.erb
+++ b/app/views/topics/show.md.erb
@@ -1,1 +1,3 @@
-../lessons/show.md.erb
+# <%= @topic.name %>
+
+<%= markdown(@topic.description) %>

--- a/spec/models/markdown_archive_spec.rb
+++ b/spec/models/markdown_archive_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownArchive do
+  let(:markdown_archive){ MarkdownArchive.new }
+
+  describe "#zip" do
+    it "should create a temp file" do
+      expect(markdown_archive.zip).to start_with("/tmp/archive")
+    end
+
+    it "should delete the temp file" do
+      expect(File.file?(markdown_archive.zip)).to eq false
+    end
+  end
+end

--- a/spec/models/markdown_archive_spec.rb
+++ b/spec/models/markdown_archive_spec.rb
@@ -1,15 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe MarkdownArchive do
-  let(:markdown_archive){ MarkdownArchive.new }
+  let(:topic){ FactoryGirl.create(:topic) }
+  let(:article){ FactoryGirl.create(:article) }
 
   describe "#zip" do
+    let(:markdown_archive){ MarkdownArchive.new(articles: [article], topics: [topic]) }
+
     it "should create a temp file" do
       expect(markdown_archive.zip).to start_with("/tmp/archive")
     end
 
-    it "should delete the temp file" do
-      expect(File.file?(markdown_archive.zip)).to eq false
+    it "should contain paths to the topics and articles it is given" do
+      tmpfile = markdown_archive.zip
+      unzippedfiles = `unzip -l #{tmpfile}`
+
+      expect(unzippedfiles).to include("Topics/A topic - Intro.md")
+      expect(unzippedfiles).to include("Articles/An article.md")
+    end
+
+    it "should not delete the temp file" do
+      expect(File.file?(markdown_archive.zip)).to eq true
     end
   end
 end

--- a/spec/models/markdown_archive_spec.rb
+++ b/spec/models/markdown_archive_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MarkdownArchive do
       tmpfile = markdown_archive.zip
       unzippedfiles = `unzip -l #{tmpfile}`
 
-      expect(unzippedfiles).to include("Topics/A topic - Intro.md")
+      expect(unzippedfiles).to include("Topics/A topic/Intro.md")
       expect(unzippedfiles).to include("Articles/An article.md")
     end
 


### PR DESCRIPTION
Previously, the markdown zipfile export function did not include lesson introductions in the archive. One change to note is that the topics markdown view used to be a symlink to the lessons `show.html.erb`, and now that symlink is gone and topics is responsible for its own markdown view.